### PR TITLE
fix: use local path to module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,8 +20,9 @@ import {init} from './init';
 import {lint} from './lint';
 import {fix} from './fix';
 
-export class Options {
+export interface Options {
   dryRun: boolean;
+  gtsRootDir: string;
   targetRootDir: string;
   yes: boolean;
 }
@@ -62,6 +63,7 @@ if (cli.input.length !== 1) {
 const verb = cli.input[0];
 const options: Options = {
   dryRun: cli.flags.dryRun || false,
+  gtsRootDir: `${process.cwd()}/node_modules/google-ts-style`,
   targetRootDir: process.cwd(),
   yes: cli.flags.yes || cli.flags.y || false
 };

--- a/src/init.ts
+++ b/src/init.ts
@@ -24,8 +24,6 @@ const readJson = pify(require('read-package-json'));
 const read = pify(fs.readFile);
 const write = pify(require('write-file-atomic'));
 
-const gtsRootDir = path.join(__dirname, '../..');
-
 interface Bag<T> {
   [script: string]: T;
 }
@@ -45,8 +43,7 @@ async function query(
   return answers.query;
 }
 
-async function generatePackageJson(
-    packageJson: any, options: Options): Promise<void> {
+async function addScripts(packageJson: any, options: Options): Promise<boolean> {
   let edits = false;
   const outDir = 'build/';
   const scripts: Bag<string> = {
@@ -79,8 +76,12 @@ async function generatePackageJson(
       }
     }
   }
+  return edits;
+}
 
-  // Install dev-dependencies.
+async function addDependencies(
+    packageJson: any, options: Options): Promise<boolean> {
+  let edits = false;
   const deps: Bag<string> = {
     'google-ts-style': 'latest',
     'clang-format': '^1.0.53',
@@ -111,11 +112,11 @@ async function generatePackageJson(
     }
   }
 
-  if (!edits) {
-    console.log('No edits needed in package.json.');
-    return;
-  }
+  return edits;
+}
 
+async function writePackageJson(
+    packageJson: any, options: Options): Promise<void> {
   console.log('Writing package.json...');
   if (!options.dryRun) {
     try {
@@ -143,14 +144,14 @@ async function generateTsConfig(options: Options): Promise<void> {
     }
   }
 
-  const pkgDir = path.relative(options.targetRootDir, gtsRootDir);
+  const pkgDir = path.relative(options.targetRootDir, options.gtsRootDir);
   const tsconfig = JSON.stringify(
       {
         extends: `${path.join(pkgDir, 'tsconfig-google.json')}`,
         include: ['src/*.ts', 'src/**/*.ts', 'test/*.ts', 'test/**/*.ts'],
         exclude: ['node_modules']
       },
-      null, '  ');
+      null, '  '); // TODO: preserve the indent from the input file.
 
   let writeTsConfig = true;
   if (existing && existing === tsconfig) {
@@ -185,18 +186,26 @@ export async function init(options: Options): Promise<void> {
     const generate =
         await query(`package.json does not exist. Generate?`, true, options);
 
-    if (generate) {
-      try {
-        cp.spawnSync('npm', ['init', '-y']);
-        packageJson = await readJson('./package.json', noop, true /* strict */);
-      } catch (err2) {
-        throw err2;
-      }
+    if (!generate) {
+      console.log('Please run from a directory with your package.json.');
+      return;
+    }
+
+    try {
+      // TODO(ofrobots): add proper error handling.
+      cp.spawnSync('npm', ['init', '-y']);
+      packageJson = await readJson('./package.json', noop, true /* strict */);
+    } catch (err2) {
+      throw err2;
     }
   }
 
-  if (packageJson) {
-    await generatePackageJson(packageJson, options);
-    await generateTsConfig(options);
+  const addedDeps = await addDependencies(packageJson, options);
+  const addedScripts = await addScripts(packageJson, options);
+  if (addedDeps || addedScripts) {
+    await writePackageJson(packageJson, options);
+  } else {
+    console.log('No edits needed in package.json.');
   }
+  await generateTsConfig(options);
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -43,7 +43,8 @@ async function query(
   return answers.query;
 }
 
-async function addScripts(packageJson: any, options: Options): Promise<boolean> {
+async function addScripts(
+    packageJson: any, options: Options): Promise<boolean> {
   let edits = false;
   const outDir = 'build/';
   const scripts: Bag<string> = {
@@ -151,7 +152,7 @@ async function generateTsConfig(options: Options): Promise<void> {
         include: ['src/*.ts', 'src/**/*.ts', 'test/*.ts', 'test/**/*.ts'],
         exclude: ['node_modules']
       },
-      null, '  '); // TODO: preserve the indent from the input file.
+      null, '  ');  // TODO: preserve the indent from the input file.
 
   let writeTsConfig = true;
   if (existing && existing === tsconfig) {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -17,17 +17,14 @@ import * as cp from 'child_process';
 import * as path from 'path';
 import {Options} from './cli';
 
-const gtsRootDir = path.join(__dirname, '../..');
-const tslintPath = path.join(gtsRootDir, '../tslint/bin/tslint');
-
 /**
  * Run tslint with the default configuration
  */
 export async function lint(options: Options): Promise<void> {
-  const pkgDir = path.relative(options.targetRootDir, gtsRootDir);
-  const args = [
-    '-c', path.join(pkgDir, 'tslint.json'), '-p', options.targetRootDir, '-t',
-    'codeFrame', '--type-check'
-  ];
-  cp.spawn(tslintPath, args, {stdio: 'inherit'});
+  const tslintPath = path.join(options.gtsRootDir, '../tslint/bin/tslint');
+  const pkgDir = path.relative(options.targetRootDir, options.gtsRootDir);
+  const args = ['-c', path.join(pkgDir, 'tslint.json'), '-p',
+                  options.targetRootDir, '-t', 'codeFrame', '--type-check'];
+  cp.spawn(tslintPath, args, { stdio: 'inherit' });
+
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -23,8 +23,9 @@ import {Options} from './cli';
 export async function lint(options: Options): Promise<void> {
   const tslintPath = path.join(options.gtsRootDir, '../tslint/bin/tslint');
   const pkgDir = path.relative(options.targetRootDir, options.gtsRootDir);
-  const args = ['-c', path.join(pkgDir, 'tslint.json'), '-p',
-                  options.targetRootDir, '-t', 'codeFrame', '--type-check'];
-  cp.spawn(tslintPath, args, { stdio: 'inherit' });
-
+  const args = [
+    '-c', path.join(pkgDir, 'tslint.json'), '-p', options.targetRootDir, '-t',
+    'codeFrame', '--type-check'
+  ];
+  cp.spawn(tslintPath, args, {stdio: 'inherit'});
 }


### PR DESCRIPTION
The paths we generate in scripts and config should be from the local
node_modules folder rather than pointing to the global directory (may
not persistent as node version changes) or npx directory (may not exist
across invocations).

Also did some refactoring.

Going to start writing tests pretty soon.