### PR TITLE
test: add fixture mechanism for unit testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,15 @@
         "@types/through": "0.0.28"
       }
     },
+    "@types/make-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/make-dir/-/make-dir-1.0.1.tgz",
+      "integrity": "sha512-+Y7xSX8lqAO+/kvX+b0j8kqYdij9y6HStnj77tOiWVlbGpBKtxjqtQlb72V5ftGNy06YOyJIdRBNQT03kwm19Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.17"
+      }
+    },
     "@types/meow": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/@types/meow/-/meow-3.6.2.tgz",
@@ -149,10 +158,14 @@
       "dev": true
     },
     "@types/rimraf": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
-      "integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.0.tgz",
+      "integrity": "sha512-wCVqPkCEQCE0H34TLDutaRLn/8RAX/OVo4egYcFKYdHUG/mWPxARKidpHji2HJdFnzd+OJSEMEmslDu7awV6kw==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "5.0.30",
+        "@types/node": "8.0.17"
+      }
     },
     "@types/rx": {
       "version": "4.1.1",
@@ -288,6 +301,12 @@
       "requires": {
         "@types/node": "8.0.17"
       }
+    },
+    "@types/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
+      "dev": true
     },
     "@types/update-notifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "tslint -c tslint.json  --project . --type-check -t codeFrame",
     "lint-fix": "tslint -c tslint.json --project .  --type-check -t codeFrame --fix",
     "release": "standard-version",
-    "test": "npm run build && ava build/test/",
+    "test": "npm run compile && ava build/test/test*.js",
     "posttest": "npm run lint && npm run format-check"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -53,16 +53,20 @@
     "@types/chalk": "^0.4.31",
     "@types/glob": "^5.0.30",
     "@types/inquirer": "0.0.35",
+    "@types/make-dir": "^1.0.1",
     "@types/meow": "^3.6.2",
     "@types/ncp": "^2.0.0",
     "@types/node": "^8.0.17",
     "@types/pify": "0.0.28",
     "@types/rimraf": "2.0.0",
+    "@types/tmp": "0.0.33",
     "@types/update-notifier": "^1.0.1",
     "ava": "^0.21.0",
+    "make-dir": "^1.0.0",
     "ncp": "^2.0.0",
     "source-map-support": "^0.4.15",
     "standard-version": "^4.2.0",
+    "tmp": "0.0.31",
     "typescript": "^2.4.1"
   },
   "peerDependencies": {
@@ -70,7 +74,7 @@
   },
   "ava": {
     "require": [
-      "source-map-support"
+      "source-map-support/register"
     ]
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,7 +76,7 @@ switch (verb) {
     init(options);
     break;
   case 'lint':
-    lint(false, options);
+    lint(options);
     break;
   case 'fix':
     fix(options);

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -22,5 +22,5 @@ import {lint} from './lint';
  * Run tslint fix and clang fix with the default configuration
  */
 export async function fix(options: Options): Promise<boolean> {
-  return lint(true, options) && await format(true, options);
+  return lint(options, true /*fix*/) && await format(true, options);
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -143,10 +143,14 @@ async function generateTsConfig(options: Options): Promise<void> {
     }
   }
 
-  const pkgDir = path.relative(options.targetRootDir, options.gtsRootDir);
+  // typescript expects relative paths to start with './'.
+  const baseConfig = './' +
+      path.relative(
+          options.targetRootDir,
+          path.resolve(options.gtsRootDir, 'tsconfig-google.json'));
   const tsconfig = JSON.stringify(
       {
-        extends: `${path.join(pkgDir, 'tsconfig-google.json')}`,
+        extends: baseConfig,
         compilerOptions: {rootDir: '.', outDir: 'build'},
         include: ['src/*.ts', 'src/**/*.ts', 'test/*.ts', 'test/**/*.ts'],
         exclude: ['node_modules']

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -24,7 +24,7 @@ import {Options} from './cli';
  * @param fix automatically fix linter errors
  * @param options google-ts-style options
  */
-export function lint(fix: boolean, options: Options): boolean {
+export function lint(options: Options, fix = false, silent = false): boolean {
   const tslintConfigPath = path.join(options.gtsRootDir, 'tslint.json');
 
   const program = createProgram(options);
@@ -32,14 +32,15 @@ export function lint(fix: boolean, options: Options): boolean {
       Configuration.findConfiguration(tslintConfigPath, '').results;
   const linter = new Linter({fix: fix, formatter: 'codeFrame'}, program);
   const files = Linter.getFileNames(program);
-  console.log(files);
   files.forEach(file => {
     const fileContents = program.getSourceFile(file).getFullText();
     linter.lint(file, fileContents, configuration);
   });
   const result = linter.getResult();
   if (result.errorCount || result.warningCount) {
-    console.log(result.output);
+    if (!silent) {
+      console.log(result.output);
+    }
     return false;
   }
   return true;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {test, Test} from 'ava';
+import * as fs from 'fs';
+import * as makeDir from 'make-dir';
+import * as path from 'path';
+import * as pify from 'pify';
+import * as tmp from 'tmp';
+
+const writeFilep = pify(fs.writeFile);
+
+export interface Fixtures {
+  // If string, we create a file with that string contents. If fixture, we
+  // create a subdirectory and recursively install the fixture.
+  // TODO: support buffers to allow non-text files.
+  [name: string]: string|Fixtures;
+}
+
+async function setupFixtures(dir: string, fixtures: Fixtures) {
+  await makeDir(dir);
+  const keys = Object.keys(fixtures);
+  for (let key of keys) {
+    const filePath = path.join(dir, key);
+    if (typeof fixtures[key] === 'string') {
+      const contents = fixtures[key] as string;
+      await writeFilep(filePath, contents);
+    } else {
+      const fixture = fixtures[key] as Fixtures;
+      await setupFixtures(filePath, fixture);
+    }
+  }
+}
+
+export async function withFixtures(
+    fixtures: Fixtures, fn: (fixturesDir: string) => Promise<any>) {
+  const keep = !!process.env.GTS_KEEP_TEMPDIRS;
+  const dir = tmp.dirSync({keep: keep, unsafeCleanup: true});
+
+  await setupFixtures(dir.name, fixtures);
+
+  const origDir = process.cwd();
+  process.chdir(dir.name);
+
+  const result = await fn(dir.name);
+
+  process.chdir(origDir);
+  if (!keep) {
+    dir.removeCallback();
+  }
+
+  return result;
+}
+
+// Problem: the following doesn't quite work with Ava. Ava expects direct calls
+// to `test`, and if it doesn't find them, it thinks that there do not exist
+// any tests in a file.
+// TODO: figure out a solution. Without this, the users of withFixtures have to
+// remember to use test.serial rather than test.
+export async function testWithFixtures(
+    name: string, fixtures: Fixtures, testFn: Test) {
+  return await withFixtures(fixtures, async () => {
+    // The tests are run serially because we chdir to temp directory.
+    return await test.serial(name, testFn);
+  });
+}

--- a/test/fixtures/kitchen/tsconfig.json
+++ b/test/fixtures/kitchen/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig-google.json",
+  "extends": "./node_modules/google-ts-style/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build"

--- a/test/test-lint.ts
+++ b/test/test-lint.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'ava';
+
+import {Options} from '../src/cli';
+import * as lint from '../src/lint';
+
+import {withFixtures} from './fixtures';
+
+const OPTIONS: Options = {
+  gtsRootDir: './',
+  targetRootDir: './',
+  dryRun: false,
+  yes: false
+};
+
+const GOOD_CODE = `
+console.log('hello world');
+`;
+
+const BAD_CODE = `console.log('hello world');`;  // no newline.
+
+const TSLINT_CONFIG = require('../../tslint.json');
+
+test.serial('createProgram should return an object', async t => {
+  await withFixtures({'tsconfig.json': '{}'}, async () => {
+    const program = lint.createProgram(OPTIONS);
+    t.truthy(program);
+  });
+});
+
+// TODO: make the error friendlier. This error implies that our module messed
+// up, or is not installed/integrated properly.
+test.serial('lint should throw error if tslint is missing', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({files: ['a.ts']}),
+        'a.ts': GOOD_CODE,
+      },
+      async () => {
+        const err = t.throws(() => {
+          lint.lint(OPTIONS);
+        });
+        t.truthy(err.message.match('Could not find config.*tslint\.json'));
+      });
+});
+
+test.serial('lint should return true on good code', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({files: ['a.ts']}),
+        'tslint.json': JSON.stringify(TSLINT_CONFIG),
+        'a.ts': GOOD_CODE,
+      },
+      async () => {
+        const okay = lint.lint(OPTIONS);
+        t.is(okay, true);
+      });
+});
+
+test.serial('lint should return false on bad code', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({files: ['a.ts']}),
+        'tslint.json': JSON.stringify(TSLINT_CONFIG),
+        'a.ts': BAD_CODE,
+      },
+      async () => {
+        const okay = lint.lint(OPTIONS, false, true /*silent*/);
+        t.is(okay, false);
+      });
+});
+
+test.serial('lint should lint files listed in tsconfig.files', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({files: ['a.ts']}),
+        'tslint.json': JSON.stringify(TSLINT_CONFIG),
+        'a.ts': GOOD_CODE,
+        'b.ts': BAD_CODE
+      },
+      async () => {
+        const okay = lint.lint(OPTIONS);
+        t.is(okay, true);
+      });
+});
+
+test.serial(
+    'lint should lint *.ts files when no files or inlcude has been specified',
+    async t => {
+      await withFixtures(
+          {
+            'tsconfig.json': JSON.stringify({}),
+            'tslint.json': JSON.stringify(TSLINT_CONFIG),
+            'a.ts': GOOD_CODE,
+            'b.ts': BAD_CODE
+          },
+          async () => {
+            const okay = lint.lint(OPTIONS, false, true /*silent*/);
+            t.is(okay, false);
+          });
+    });
+
+test.serial('lint should not lint files listed in exclude', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({exclude: ['b.*']}),
+        'tslint.json': JSON.stringify(TSLINT_CONFIG),
+        'a.ts': GOOD_CODE,
+        'b.ts': BAD_CODE
+      },
+      async () => {
+        const okay = lint.lint(OPTIONS);
+        t.is(okay, true);
+      });
+});
+
+test.serial('lint should lint globs listed in include', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({include: ['dirb/*']}),
+        'tslint.json': JSON.stringify(TSLINT_CONFIG),
+        dira: {'a.ts': GOOD_CODE},
+        dirb: {'b.ts': BAD_CODE}
+      },
+      async () => {
+        const okay = lint.lint(OPTIONS, false, true /*silent*/);
+        t.is(okay, false);
+      });
+});
+
+// TODO: test for when tsconfig.json is missing.

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -20,9 +20,7 @@ import {getTSConfig} from '../src/util';
 
 test('get should parse the correct tsconfig file', async t => {
   const FAKE_DIRECTORY = '/some/fake/directory';
-  const FAKE_CONFIG = {
-    a: 'b'
-  };
+  const FAKE_CONFIG = {a: 'b'};
   function fakeReadFilep(configPath: string, encoding: string): Promise<any> {
     t.is(configPath, path.join(FAKE_DIRECTORY, 'tsconfig.json'));
     t.is(encoding, 'utf8');

--- a/tsconfig-google.json
+++ b/tsconfig-google.json
@@ -14,7 +14,7 @@
     "pretty": true,
     "strict": true,
     "module": "commonjs",
-    "target": "es6",
+    "target": "es5",
     "sourceMap": true
   },
   "exclude": [


### PR DESCRIPTION
Makes it possible to run runs with fixtures without having out of band
fixtures directories.

Add tests for lint.ts.