### PR TITLE
drop noUnusedParameters

### DIFF
--- a/tsconfig-google.json
+++ b/tsconfig-google.json
@@ -9,8 +9,6 @@
     "noFallthroughCasesInSwitch": true,
     "noEmitOnError": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "pretty": true,
     "strict": true,
     "module": "commonjs",


### PR DESCRIPTION
The internal Google configuration doesn't use this flag.
Fixes: https://github.com/google/ts-style/issues/39