### PR TITLE
Replace read-package-json with vanilla JSON.parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "inquirer": "^3.2.1",
     "meow": "^3.7.0",
     "pify": "^3.0.0",
-    "read-package-json": "^2.0.10",
     "rimraf": "^2.6.1",
     "tslint": "^5.5.0",
     "update-notifier": "^2.2.0",

--- a/src/init.ts
+++ b/src/init.ts
@@ -25,10 +25,6 @@ interface Bag<T> {
   [script: string]: T;
 }
 
-function noop() {
-  /* empty */
-}
-
 async function query(
     message: string, question: string, defaultVal: boolean,
     options: Options): Promise<boolean> {
@@ -184,7 +180,7 @@ async function generateTsConfig(options: Options): Promise<void> {
 export async function init(options: Options): Promise<boolean> {
   let packageJson;
   try {
-    packageJson = await readJson('./package.json', noop, true /*strict*/);
+    packageJson = await readJson('./package.json');
   } catch (err) {
     if (err.code !== 'ENOENT') {
       throw new Error(`Unable to open package.json file: ${err.message}`);
@@ -201,7 +197,7 @@ export async function init(options: Options): Promise<boolean> {
     try {
       // TODO(ofrobots): add proper error handling.
       cp.spawnSync('npm', ['init', '-y']);
-      packageJson = await readJson('./package.json', noop, true /* strict */);
+      packageJson = await readJson('./package.json');
     } catch (err2) {
       throw err2;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,9 +20,12 @@ import * as pify from 'pify';
 import * as rimraf from 'rimraf';
 
 export const readFilep = pify(fs.readFile);
-export const readJsonp = pify(require('read-package-json'));
 export const rimrafp = pify(rimraf);
 export const writeFileAtomicp = pify(require('write-file-atomic'));
+
+export async function readJsonp(jsonPath: string) {
+  return JSON.parse(await readFilep(jsonPath));
+}
 
 export interface ReadFileP { (path: string, encoding: string): Promise<any>; }
 


### PR DESCRIPTION
`read-package-json` [inserts a number of fields](https://github.com/GoogleCloudPlatform/cloud-trace-nodejs/pull/554/files/6e59f889f953868ebe198969be7908400af202f1..e875441c58e0de2cfd0e1784605cfcf0d6986311#r139029874) that we likely don't want to write to the user's `package.json` file. This change replaces it with `readFilep` followed by `JSON.parse`.

We might lose some guarantee about the structure of the `package.json` file being read (seems like `read-package-json` does some extra checks)... but these cases might be unrecoverable either way.