### PR TITLE
fix: ignore files that are not found

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -35,8 +35,11 @@ export function lint(
   const linter = new Linter({fix, formatter: 'codeFrame'}, program);
   const srcFiles = files.length > 0 ? files : Linter.getFileNames(program);
   srcFiles.forEach(file => {
-    const fileContents = program.getSourceFile(file).getFullText();
-    linter.lint(file, fileContents, configuration);
+    const sourceFile = program.getSourceFile(file);
+    if (sourceFile) {
+      const fileContents = sourceFile.getFullText();
+      linter.lint(file, fileContents, configuration);
+    }
   });
   const result = linter.getResult();
   if (result.errorCount || result.warningCount) {

--- a/test/test-lint.ts
+++ b/test/test-lint.ts
@@ -158,4 +158,17 @@ test.serial('lint should lint only specified files', async t => {
       });
 });
 
+test.serial('lint should not throw for unrecognized files', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({}),
+        'tslint.json': JSON.stringify(TSLINT_CONFIG),
+        'a.ts': GOOD_CODE,
+      },
+      async () => {
+        lint.lint(OPTIONS, ['z.ts']);
+        t.pass();
+      });
+});
+
 // TODO: test for when tsconfig.json is missing.


### PR DESCRIPTION
This is needed when files are explicitly passed to
gts. Just ignore them.

This addresses https://github.com/google/ts-style/issues/86