### PR TITLE
fix: correct gts root directory

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as path from 'path';
 import * as meow from 'meow';
 import * as updateNotifier from 'update-notifier';
 import {init} from './init';
@@ -71,7 +72,7 @@ function usage(msg?: string): void {
 async function run(verb: string, files: string[]): Promise<boolean> {
   const options: Options = {
     dryRun: cli.flags.dryRun || false,
-    gtsRootDir: `${process.cwd()}/node_modules/gts`,
+    gtsRootDir: path.resolve(__dirname, '../..'),
     targetRootDir: process.cwd(),
     yes: cli.flags.yes || cli.flags.y || false,
     logger

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,6 +72,7 @@ function usage(msg?: string): void {
 async function run(verb: string, files: string[]): Promise<boolean> {
   const options: Options = {
     dryRun: cli.flags.dryRun || false,
+    // Paths are relative to the transpiled output files.
     gtsRootDir: path.resolve(__dirname, '../..'),
     targetRootDir: process.cwd(),
     yes: cli.flags.yes || cli.flags.y || false,

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -74,6 +74,20 @@ test.before(async () => {
   await simpleExecp('npm install', execOpts);
 });
 
+test.serial('use as a non-locally installed module', async t => {
+  // Use from a directory different from where we have locally installed. This
+  // simulates use as a globally installed module.
+  const GTS = `${stagingPath}/kitchen/node_modules/.bin/gts`;
+  const tmpDir = tmp.dirSync({keep, unsafeCleanup: true});
+  await ncpp('test/fixtures', `${tmpDir.name}/`);
+  await simpleExecp(
+      `${GTS} check kitchen/src/server.ts`, {cwd: `${tmpDir.name}/kitchen`});
+  if (!keep) {
+    tmpDir.removeCallback();
+  }
+  t.pass();
+});
+
 test.serial('init', async t => {
   await simpleExecp('./node_modules/.bin/gts init -y', execOpts);
   fs.accessSync(`${stagingPath}/kitchen/tsconfig.json`);


### PR DESCRIPTION
Fixes: https://github.com/google/ts-style/issues/83

Done ~~We need tests for use as a global install module.~~

Done #89 ~~It is worth noting that we do not expect `gts compile` to work from a globally installed version. We need to detect that case and show an error to the user in that scenario.~~  