### PR TITLE
fix: format root files only

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -31,13 +31,10 @@ export async function format(
     options: Options, files: string[] = [], fix = false): Promise<boolean> {
   const program = createProgram(options);
   const srcFiles = files.length > 0 ?
-      files :
-      program.getSourceFiles()
-          .map(sourceFile => sourceFile.fileName)
-          .filter(f => !f.endsWith('.d.ts'));
+      files : program.getRootFileNames().filter(f => !f.endsWith('.d.ts'));
 
   if (fix) {
-    return fixFormat(srcFiles);
+    return await fixFormat(srcFiles);
   } else {
     const result = await checkFormat(srcFiles);
     if (!result) {

--- a/src/format.ts
+++ b/src/format.ts
@@ -30,6 +30,12 @@ const baseArgs =
 export async function format(
     options: Options, files: string[] = [], fix = false): Promise<boolean> {
   const program = createProgram(options);
+  // Obtain a list of source files to format.
+  // We use program.getRootFileNames to get only the files that match the
+  // include patterns specified in the given tsconfig.json file (as specified
+  // through options). This is necessary because we only want to format files
+  // over which the developer has control (i.e. not auto-generated or
+  // third-party source files).
   const srcFiles = files.length > 0 ?
       files :
       program.getRootFileNames().filter(f => !f.endsWith('.d.ts'));

--- a/src/format.ts
+++ b/src/format.ts
@@ -31,7 +31,8 @@ export async function format(
     options: Options, files: string[] = [], fix = false): Promise<boolean> {
   const program = createProgram(options);
   const srcFiles = files.length > 0 ?
-      files : program.getRootFileNames().filter(f => !f.endsWith('.d.ts'));
+      files :
+      program.getRootFileNames().filter(f => !f.endsWith('.d.ts'));
 
   if (fix) {
     return await fixFormat(srcFiles);
@@ -70,6 +71,7 @@ function fixFormat(srcFiles: string[]): Promise<boolean> {
  * @param srcFiles list of source files
  */
 function checkFormat(srcFiles: string[]): Promise<boolean> {
+  console.log(srcFiles);
   return new Promise<boolean>((resolve, reject) => {
     let output = '';
     const args = baseArgs.concat(['-output-replacements-xml'], srcFiles);

--- a/src/format.ts
+++ b/src/format.ts
@@ -71,7 +71,6 @@ function fixFormat(srcFiles: string[]): Promise<boolean> {
  * @param srcFiles list of source files
  */
 function checkFormat(srcFiles: string[]): Promise<boolean> {
-  console.log(srcFiles);
   return new Promise<boolean>((resolve, reject) => {
     let output = '';
     const args = baseArgs.concat(['-output-replacements-xml'], srcFiles);

--- a/test/fixtures/kitchen/src/server.ts
+++ b/test/fixtures/kitchen/src/server.ts
@@ -1,1 +1,1 @@
-  const isThisTypeScript = true
+  export const isThisTypeScript = true

--- a/test/fixtures/kitchen/src/server.ts
+++ b/test/fixtures/kitchen/src/server.ts
@@ -1,1 +1,1 @@
-  export const isThisTypeScript = true
+  const isThisTypeScript = true

--- a/test/test-format.ts
+++ b/test/test-format.ts
@@ -36,10 +36,7 @@ const OPTIONS: Options = {
 
 test.serial('format should return false for ill-formatted files', async t => {
   await withFixtures(
-      {
-        'tsconfig.json': JSON.stringify({files: ['a.ts']}),
-        'a.ts': BAD_CODE
-      },
+      {'tsconfig.json': JSON.stringify({files: ['a.ts']}), 'a.ts': BAD_CODE},
       async () => {
         const result = await format.format(OPTIONS, [], false);
         t.false(result);

--- a/test/test-format.ts
+++ b/test/test-format.ts
@@ -48,7 +48,7 @@ test.serial('format should only look in root files', async t => {
       {
         'tsconfig.json': JSON.stringify({files: ['a.ts']}),
         'a.ts': 'import {foo} from \'./b\';\n',
-        'b.ts': 'export const foo = 2;  '
+        'b.ts': 'export const foo = 2;  '  // trailing spaces
       },
       async () => {
         const result = await format.format(OPTIONS, [], false);

--- a/test/test-format.ts
+++ b/test/test-format.ts
@@ -22,6 +22,9 @@ import {nop} from '../src/util';
 
 import {withFixtures} from './fixtures';
 
+// clang-format won't pass this code because of trailing spaces.
+const BAD_CODE = 'export const foo = 2;  ';
+
 const OPTIONS: Options = {
   gtsRootDir: './',
   targetRootDir: './',
@@ -35,7 +38,7 @@ test.serial('format should return false for ill-formatted files', async t => {
   await withFixtures(
       {
         'tsconfig.json': JSON.stringify({files: ['a.ts']}),
-        'a.ts': 'export const foo = 2;  '
+        'a.ts': BAD_CODE
       },
       async () => {
         const result = await format.format(OPTIONS, [], false);
@@ -48,7 +51,7 @@ test.serial('format should only look in root files', async t => {
       {
         'tsconfig.json': JSON.stringify({files: ['a.ts']}),
         'a.ts': 'import {foo} from \'./b\';\n',
-        'b.ts': 'export const foo = 2;  '  // trailing spaces
+        'b.ts': BAD_CODE
       },
       async () => {
         const result = await format.format(OPTIONS, [], false);

--- a/test/test-format.ts
+++ b/test/test-format.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'ava';
+
+import {Options} from '../src/cli';
+import * as format from '../src/format';
+import {nop} from '../src/util';
+
+import {withFixtures} from './fixtures';
+
+const OPTIONS: Options = {
+  gtsRootDir: './',
+  targetRootDir: './',
+  dryRun: false,
+  yes: false,
+  no: false,
+  logger: {log: console.log, error: console.error, dir: nop}
+};
+
+test.serial('format should return false for ill-formatted files', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({files: ['a.ts']}),
+        'a.ts': 'export const foo = 2;  '
+      },
+      async () => {
+        const result = await format.format(OPTIONS, [], false);
+        t.false(result);
+      });
+});
+
+test.serial('format should only look in root files', async t => {
+  await withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({files: ['a.ts']}),
+        'a.ts': 'import {foo} from \'./b\';\n',
+        'b.ts': 'export const foo = 2;  '
+      },
+      async () => {
+        const result = await format.format(OPTIONS, [], false);
+        t.true(result);
+      });
+});
+
+// TODO: Add more tests


### PR DESCRIPTION
Fixes #98

We should use `getRootFileNames` instead of `getSourceFiles` when retrieving a list of files to format; the latter gets every files in the dependency graph constructed from files included in `tsconfig.json`.