### PR TITLE
fix(init): use ~ semver range for typescript

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -93,7 +93,7 @@ async function addScripts(
 async function addDependencies(
     packageJson: PackageJson, options: Options): Promise<boolean> {
   let edits = false;
-  const deps: Bag<string> = {'gts': `^${pkg.version}`, 'typescript': '^2.6.1'};
+  const deps: Bag<string> = {'gts': `^${pkg.version}`, 'typescript': '~2.6.1'};
 
   if (!packageJson.devDependencies) {
     packageJson.devDependencies = {};


### PR DESCRIPTION
TypeScript doesn't follow semver, but we do. It makes sense to default
to a ~ semver range for typescript in the client projects, rather them
letting them stumble into the subtlety.