### PR TITLE
fix: use local gts path for generated tsconfig.json

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -152,13 +152,8 @@ async function generateTsConfig(options: Options): Promise<void> {
     }
   }
 
-  // typescript expects relative paths to start with './'.
-  const baseConfig = './' +
-      path.relative(
-          options.targetRootDir,
-          path.resolve(options.gtsRootDir, 'tsconfig-google.json'));
   const tsconfig = formatJson({
-    extends: baseConfig,
+    extends: './node_modules/gts/tsconfig-google.json',
     compilerOptions: {rootDir: '.', outDir: 'build'},
     include: ['src/*.ts', 'src/**/*.ts', 'test/*.ts', 'test/**/*.ts'],
     exclude: ['node_modules']

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -85,8 +85,13 @@ test.serial('init', async t => {
         `npx -p ${stagingPath}/gts.tgz --ignore-existing gts init -n`,
         execOpts);
   }
-  fs.accessSync(`${stagingPath}/kitchen/tsconfig.json`);
-  t.pass();
+  const tsconfigPath = `${stagingPath}/kitchen/tsconfig.json`;
+  fs.accessSync(tsconfigPath);
+
+  // The `extends` field must use the local gts path.
+  const tsconfigJson = fs.readFileSync(tsconfigPath, 'utf8');
+  const tsconfig = JSON.parse(tsconfigJson);
+  t.deepEqual(tsconfig.extends, './node_modules/gts/tsconfig-google.json');
 });
 
 test.serial('use as a non-locally installed module', async t => {

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -85,13 +85,8 @@ test.serial('init', async t => {
         `npx -p ${stagingPath}/gts.tgz --ignore-existing gts init -n`,
         execOpts);
   }
-  const tsconfigPath = `${stagingPath}/kitchen/tsconfig.json`;
-  fs.accessSync(tsconfigPath);
-
-  // The `extends` field must use the local gts path.
-  const tsconfigJson = fs.readFileSync(tsconfigPath, 'utf8');
-  const tsconfig = JSON.parse(tsconfigJson);
-  t.deepEqual(tsconfig.extends, './node_modules/gts/tsconfig-google.json');
+  fs.accessSync(`${stagingPath}/kitchen/tsconfig.json`);
+  t.pass();
 });
 
 test.serial('use as a non-locally installed module', async t => {
@@ -100,10 +95,15 @@ test.serial('use as a non-locally installed module', async t => {
   const GTS = `${stagingPath}/kitchen/node_modules/.bin/gts`;
   const tmpDir = tmp.dirSync({keep, unsafeCleanup: true});
   await ncpp('test/fixtures', `${tmpDir.name}/`);
+
   const opts = {cwd: `${tmpDir.name}/kitchen`};
-  // It's important to use `-n` here because we don't want to overwrite
-  // the version of gts installed, as it will trigger the npm install.
-  await simpleExecp(`${GTS} init -n`, opts);
+  await simpleExecp(`${GTS} init -y`, opts);
+  // The `extends` field must use the local gts path.
+  const tsconfigJson =
+      fs.readFileSync(`${tmpDir.name}/kitchen/tsconfig.json`, 'utf8');
+  const tsconfig = JSON.parse(tsconfigJson);
+  t.deepEqual(tsconfig.extends, './node_modules/gts/tsconfig-google.json');
+
   await simpleExecp(`${GTS} check kitchen/src/server.ts`, opts);
   if (!keep) {
     tmpDir.removeCallback();


### PR DESCRIPTION
Currently the global gts path is used when `gts init` is done using a
globally installed `gts`, which is a usual workflow.