### PR TITLE
feat: use typescript 2.7.1 and esModuleInterop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,64 @@
         "arrify": "1.0.1"
       }
     },
+    "@ladjs/time-require": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
+      "integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "0.4.0",
+        "date-time": "0.1.1",
+        "pretty-ms": "0.2.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
+          }
+        },
+        "date-time": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
+          "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
+          "dev": true
+        },
+        "parse-ms": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
+          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
+          "dev": true
+        },
+        "pretty-ms": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
+          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
+          "dev": true,
+          "requires": {
+            "parse-ms": "0.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+          "dev": true
+        }
+      }
+    },
     "@types/glob": {
       "version": "5.0.30",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.30.tgz",
@@ -303,9 +361,9 @@
       "dev": true
     },
     "@types/update-notifier": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-1.0.1.tgz",
-      "integrity": "sha1-R+jwB8a1vK++QnMy47a0M83Bjdw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-2.0.0.tgz",
+      "integrity": "sha512-O/LFDBg0M6QADktkMYlxuBYxEsQnVmYvXTK+ezfFjBHr+n4WGaC3KAQJx/JmGKDOZYxPyyIcosuSjLB+HmjRkg==",
       "dev": true
     },
     "ajv": {
@@ -358,7 +416,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -463,15 +520,16 @@
       "dev": true
     },
     "ava": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
-      "integrity": "sha1-3QqzOgs60qxYL1Xpphyvi896mvE=",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-0.25.0.tgz",
+      "integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
       "dev": true,
       "requires": {
         "@ava/babel-preset-stage-4": "1.1.0",
         "@ava/babel-preset-transform-test-files": "3.0.0",
         "@ava/write-file-atomic": "2.2.0",
         "@concordance/react": "1.0.0",
+        "@ladjs/time-require": "0.1.4",
         "ansi-escapes": "3.0.0",
         "ansi-styles": "3.2.0",
         "arr-flatten": "1.1.0",
@@ -493,7 +551,7 @@
         "cli-spinners": "1.1.0",
         "cli-truncate": "1.1.0",
         "co-with-promise": "4.6.0",
-        "code-excerpt": "2.1.0",
+        "code-excerpt": "2.1.1",
         "common-path-prefix": "1.0.0",
         "concordance": "3.0.0",
         "convert-source-map": "1.5.1",
@@ -518,7 +576,6 @@
         "is-obj": "1.0.1",
         "is-observable": "1.1.0",
         "is-promise": "2.1.0",
-        "js-yaml": "3.10.0",
         "last-line-stream": "1.0.0",
         "lodash.clonedeepwith": "4.5.0",
         "lodash.debounce": "4.0.8",
@@ -540,14 +597,14 @@
         "require-precompiled": "0.1.0",
         "resolve-cwd": "2.0.0",
         "safe-buffer": "5.1.1",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "slash": "1.0.0",
         "source-map-support": "0.5.0",
         "stack-utils": "1.0.1",
         "strip-ansi": "4.0.0",
         "strip-bom-buf": "1.0.0",
+        "supertap": "1.0.0",
         "supports-color": "5.1.0",
-        "time-require": "0.1.2",
         "trim-off-newlines": "1.0.1",
         "unique-temp-dir": "1.0.0",
         "update-notifier": "2.3.0"
@@ -556,7 +613,7 @@
         "ansi-escapes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-          "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
           "dev": true
         },
         "ansi-regex": {
@@ -579,6 +636,15 @@
           "requires": {
             "camelcase": "2.1.1",
             "map-obj": "1.0.1"
+          }
+        },
+        "code-excerpt": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
+          "integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+          "dev": true,
+          "requires": {
+            "convert-to-spaces": "1.0.2"
           }
         },
         "find-up": {
@@ -721,9 +787,9 @@
           }
         },
         "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "strip-ansi": {
@@ -756,7 +822,7 @@
         "supports-color": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha1-BYoCHRthn33fOYDXEuo1kM5949U=",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -1647,15 +1713,6 @@
         "pinkie-promise": "1.0.0"
       }
     },
-    "code-excerpt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.0.tgz",
-      "integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
-      "dev": true,
-      "requires": {
-        "convert-to-spaces": "1.0.2"
-      }
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1693,11 +1750,6 @@
       "requires": {
         "delayed-stream": "1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "common-path-prefix": {
       "version": "1.0.0",
@@ -1990,8 +2042,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "espurify": {
       "version": "1.7.0",
@@ -3697,9 +3748,9 @@
       "dev": true
     },
     "js-green-licenses": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.3.1.tgz",
-      "integrity": "sha512-pFWoi11NZuQPt0emRrQKVi+DVjLUYSE+v/cbMzWIrce+2CvkQ5PQUHwJwXua835Q4RpJMe2BxR66VU7BC1Tusg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.4.0.tgz",
+      "integrity": "sha512-LpkL/9coWxNUmJ9/jxng3uvcLK6Qso2yaz7QBjO+atwtX/xmt8MrCtbkolYdhPZl/fq5dRs7Q7BLA8Ne3DKZ2w==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -3755,7 +3806,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -6465,6 +6515,12 @@
         "semver": "5.3.0"
       }
     },
+    "serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
+      "dev": true
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -6603,8 +6659,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
@@ -6712,6 +6767,36 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
+    "supertap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
+      "integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "indent-string": "3.2.0",
+        "js-yaml": "3.10.0",
+        "serialize-error": "2.1.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
     "supports-color": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
@@ -6753,64 +6838,6 @@
       "requires": {
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
-      }
-    },
-    "time-require": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
-      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "dev": true,
-      "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "date-time": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-          "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-          "dev": true
-        },
-        "parse-ms": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-          "dev": true
-        },
-        "pretty-ms": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-          "dev": true,
-          "requires": {
-            "parse-ms": "0.1.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
-        }
       }
     },
     "time-zone": {
@@ -6870,21 +6897,29 @@
       "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
     },
     "tslint": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
-      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "requires": {
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
         "chalk": "2.3.0",
-        "commander": "2.11.0",
+        "commander": "2.13.0",
         "diff": "3.4.0",
         "glob": "7.1.2",
+        "js-yaml": "3.10.0",
         "minimatch": "3.0.4",
         "resolve": "1.3.3",
         "semver": "5.3.0",
         "tslib": "1.8.0",
         "tsutils": "2.12.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+        }
       }
     },
     "tsutils": {
@@ -6912,9 +6947,9 @@
       "optional": true
     },
     "typescript": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
-      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
       "dev": true
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "meow": "^4.0.0",
     "pify": "^3.0.0",
     "rimraf": "^2.6.1",
-    "tslint": "^5.8.0",
+    "tslint": "^5.9.1",
     "update-notifier": "^2.2.0",
     "write-file-atomic": "^2.1.0"
   },
@@ -68,7 +68,7 @@
     "nyc": "^11.2.1",
     "source-map-support": "^0.5.0",
     "tmp": "0.0.31",
-    "typescript": "~2.6.1"
+    "typescript": "~2.7.1"
   },
   "peerDependencies": {
     "typescript": "^2.6.1"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 import * as path from 'path';
-import * as meow from 'meow';
-import * as updateNotifier from 'update-notifier';
+import meow from 'meow';
+import updateNotifier from 'update-notifier';
 import {init} from './init';
 import {clean} from './clean';
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -93,7 +93,7 @@ async function addScripts(
 async function addDependencies(
     packageJson: PackageJson, options: Options): Promise<boolean> {
   let edits = false;
-  const deps: Bag<string> = {'gts': `^${pkg.version}`, 'typescript': '~2.6.1'};
+  const deps: Bag<string> = {'gts': `^${pkg.version}`, 'typescript': '~2.7.1'};
 
   if (!packageJson.devDependencies) {
     packageJson.devDependencies = {};

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,8 +16,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as pify from 'pify';
-import * as rimraf from 'rimraf';
+import pify from 'pify';
+import rimraf from 'rimraf';
 
 export const readFilep = pify(fs.readFile);
 export const rimrafp = pify(rimraf);

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -16,9 +16,9 @@
 
 import {test, Test} from 'ava';
 import * as fs from 'fs';
-import * as makeDir from 'make-dir';
+import makeDir from 'make-dir';
 import * as path from 'path';
-import * as pify from 'pify';
+import pify from 'pify';
 import * as tmp from 'tmp';
 
 const writeFilep = pify(fs.writeFile);

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -4,8 +4,8 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as ncp from 'ncp';
 import * as path from 'path';
-import * as pify from 'pify';
-import * as rimraf from 'rimraf';
+import pify from 'pify';
+import rimraf from 'rimraf';
 import * as tmp from 'tmp';
 
 interface ExecResult {

--- a/tsconfig-google.json
+++ b/tsconfig-google.json
@@ -1,19 +1,20 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "declaration": true,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2015"],
-    "noFallthroughCasesInSwitch": true,
+    "module": "commonjs",
     "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "pretty": true,
+    "sourceMap": true,
     "strict": true,
-    "module": "commonjs",
-    "target": "es5",
-    "sourceMap": true
+    "target": "es5"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
[BREAKING CHANGE]

This PR is both for the generated `package.json` and `gts` itself.

TypeScript 2.7.1 added `--esModuleInterop` for better ES module
support. And for that, we need to turn on `allowSyntheticDefaultImports`
too.

Also `tslint` must be upgraded to 5.9.1 for it to compile with
`esModuleInterop`.