### PR TITLE
feat: upgrade to Typescript 2.8.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,16 @@
         "@types/node": "9.3.0"
       }
     },
+    "@types/inquirer": {
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.40.tgz",
+      "integrity": "sha512-MEUWlhRf/BxZIXHD4p3AR/HnmZYHBLoIDqwZcNB8wNWsIFyEOZPh23b0LFAnKDPYOdgD6Kz9Ju4K661AC/zBng==",
+      "dev": true,
+      "requires": {
+        "@types/rx": "4.1.1",
+        "@types/through": "0.0.29"
+      }
+    },
     "@types/make-dir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/make-dir/-/make-dir-1.0.1.tgz",
@@ -206,6 +216,141 @@
         "@types/node": "9.3.0"
       }
     },
+    "@types/rx": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
+      "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3",
+        "@types/rx-core-binding": "4.0.4",
+        "@types/rx-lite": "4.0.5",
+        "@types/rx-lite-aggregates": "4.0.3",
+        "@types/rx-lite-async": "4.0.2",
+        "@types/rx-lite-backpressure": "4.0.3",
+        "@types/rx-lite-coincidence": "4.0.3",
+        "@types/rx-lite-experimental": "4.0.1",
+        "@types/rx-lite-joinpatterns": "4.0.1",
+        "@types/rx-lite-testing": "4.0.1",
+        "@types/rx-lite-time": "4.0.3",
+        "@types/rx-lite-virtualtime": "4.0.3"
+      }
+    },
+    "@types/rx-core": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz",
+      "integrity": "sha1-CzNUsSOM7b4rdPYybxOdvHpZHWA=",
+      "dev": true
+    },
+    "@types/rx-core-binding": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
+      "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3"
+      }
+    },
+    "@types/rx-lite": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.5.tgz",
+      "integrity": "sha512-KZk5XTR1dm/kNgBx8iVpjno6fRYtAUQWBOmj+O8j724+nk097sz4fOoHJNpCkOJUtHUurZlJC7QvSFCZHbkC+w==",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3",
+        "@types/rx-core-binding": "4.0.4"
+      }
+    },
+    "@types/rx-lite-aggregates": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
+      "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
+    },
+    "@types/rx-lite-async": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
+      "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
+    },
+    "@types/rx-lite-backpressure": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
+      "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
+    },
+    "@types/rx-lite-coincidence": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
+      "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
+    },
+    "@types/rx-lite-experimental": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
+      "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
+    },
+    "@types/rx-lite-joinpatterns": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
+      "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
+    },
+    "@types/rx-lite-testing": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
+      "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite-virtualtime": "4.0.3"
+      }
+    },
+    "@types/rx-lite-time": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
+      "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
+    },
+    "@types/rx-lite-virtualtime": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
+      "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.5"
+      }
+    },
+    "@types/through": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
+      "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.3.0"
+      }
+    },
     "@types/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
@@ -268,7 +413,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -803,7 +947,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -813,14 +956,12 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
             "escape-string-regexp": "1.0.5",
@@ -832,8 +973,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -1616,6 +1756,11 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+    },
     "common-path-prefix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
@@ -1837,6 +1982,11 @@
         "repeating": "2.0.1"
       }
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -1910,8 +2060,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "espurify": {
       "version": "1.7.0",
@@ -1931,8 +2080,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "execa": {
       "version": "0.7.0",
@@ -3670,14 +3818,12 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
       "requires": {
         "argparse": "1.0.10",
         "esprima": "4.0.0"
@@ -6577,8 +6723,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
@@ -6810,6 +6955,38 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+    },
+    "tslint": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.15.1",
+        "diff": "3.5.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.10.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.3.3",
+        "semver": "5.3.0",
+        "tslib": "1.9.0",
+        "tsutils": "2.25.0"
+      }
+    },
+    "tsutils": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.25.0.tgz",
+      "integrity": "sha512-SPgUlOAUAe6fCyPi0QR4U0jRuDsHHKvzIR6/hHd0YR0bb8MzeLJgCagkPSmZeJjWImnpJ0xq6XHa9goTvMBBCQ==",
+      "requires": {
+        "tslib": "1.9.0"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -6827,9 +7004,9 @@
       "optional": true
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
       "dev": true
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nyc": "^11.2.1",
     "source-map-support": "^0.5.0",
     "tmp": "0.0.31",
-    "typescript": "~2.7.1"
+    "typescript": "~2.8.0"
   },
   "peerDependencies": {
     "typescript": "^2.7.1"

--- a/src/init.ts
+++ b/src/init.ts
@@ -93,7 +93,7 @@ async function addScripts(
 async function addDependencies(
     packageJson: PackageJson, options: Options): Promise<boolean> {
   let edits = false;
-  const deps: Bag<string> = {'gts': `^${pkg.version}`, 'typescript': '~2.7.1'};
+  const deps: Bag<string> = {'gts': `^${pkg.version}`, 'typescript': '~2.8.0'};
 
   if (!packageJson.devDependencies) {
     packageJson.devDependencies = {};


### PR DESCRIPTION
This is for the next branch.

Update the typescript dependency to 2.8.x both for the locally used dev
dependency and the version we emit in the generated package.json. The
peerDependency remains unchanged, which makes this a semver-minor.

Existing projects already have a dependency on typescript in their
package.json, so they should continue using the pre-2.8 version.

New versions projects will get 2.8.1+.