### PR TITLE
fix: don't compile right after generating a project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
       }
     },
     "@types/inquirer": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.38.tgz",
-      "integrity": "sha512-RyZaZKuHFAQTZcrVaW7QgdMYYqEk2FS3eNLfU1rszURBehIiOtiv3AXVkelAVNmZb9dD6pruXaom/5V57pMcEQ==",
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.40.tgz",
+      "integrity": "sha512-MEUWlhRf/BxZIXHD4p3AR/HnmZYHBLoIDqwZcNB8wNWsIFyEOZPh23b0LFAnKDPYOdgD6Kz9Ju4K661AC/zBng==",
       "dev": true,
       "requires": {
         "@types/rx": "4.1.1",

--- a/src/init.ts
+++ b/src/init.ts
@@ -215,7 +215,9 @@ export async function init(options: Options): Promise<boolean> {
 
   // Run `npm install` after initial setup so `npm run check` works right away.
   if (!options.dryRun) {
-    cp.spawnSync('npm', ['install'], {stdio: 'inherit'});
+    // --ignore-scripts so that compilation doesn't happen because there's no
+    // source files yet.
+    cp.spawnSync('npm', ['install', '--ignore-scripts'], {stdio: 'inherit'});
   }
 
   return true;

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -113,6 +113,10 @@ test.serial('use as a non-locally installed module', async t => {
   // server.ts has a lint error. Should error.
   await t.throws(simpleExecp(`${GTS} check src/server.ts`, opts));
 
+  // Compilation shouldn't have happened. Hence no `build` directory.
+  const dirContents = fs.readdirSync(`${tmpDir.name}/kitchen`);
+  t.is(dirContents.indexOf('build'), -1);
+
   if (!keep) {
     tmpDir.removeCallback();
   }

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -86,6 +86,11 @@ test.serial('init', async t => {
         execOpts);
   }
   fs.accessSync(`${stagingPath}/kitchen/tsconfig.json`);
+
+  // Compilation shouldn't have happened. Hence no `build` directory.
+  const dirContents = fs.readdirSync(`${stagingPath}/kitchen`);
+  t.is(dirContents.indexOf('build'), -1);
+
   t.pass();
 });
 
@@ -112,10 +117,6 @@ test.serial('use as a non-locally installed module', async t => {
 
   // server.ts has a lint error. Should error.
   await t.throws(simpleExecp(`${GTS} check src/server.ts`, opts));
-
-  // Compilation shouldn't have happened. Hence no `build` directory.
-  const dirContents = fs.readdirSync(`${tmpDir.name}/kitchen`);
-  t.is(dirContents.indexOf('build'), -1);
 
   if (!keep) {
     tmpDir.removeCallback();


### PR DESCRIPTION
Compilation would fail because there's no source files.