### PR TITLE
fix: exclude section is not necessary

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -155,8 +155,7 @@ async function generateTsConfig(options: Options): Promise<void> {
   const tsconfig = formatJson({
     extends: './node_modules/gts/tsconfig-google.json',
     compilerOptions: {rootDir: '.', outDir: 'build'},
-    include: ['src/*.ts', 'src/**/*.ts', 'test/*.ts', 'test/**/*.ts'],
-    exclude: ['node_modules']
+    include: ['src/*.ts', 'src/**/*.ts', 'test/*.ts', 'test/**/*.ts']
   });
 
   let writeTsConfig = true;


### PR DESCRIPTION
tsconfig.json doesn't need an exclude section when an include section
is present.

Fixes: https://github.com/google/ts-style/issues/70