### PR TITLE
chore: drop support for Node 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node4:
-          filters: *release_tags
       - node6:
           filters: *release_tags
       - node8:
@@ -33,7 +31,6 @@ workflows:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node4
             - node6
             - node8
             - node9
@@ -43,11 +40,6 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node4:
-    docker:
-      - image: node:4
-        user: node
-    <<: *unit_tests
   node6:
     docker:
       - image: node:6

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "license-check": "jsgl --local ."
   },
   "engines": {
-    "node": ">=4"
+    "node": ">6"
   },
   "keywords": [],
   "author": "Google Inc.",


### PR DESCRIPTION
BREAKING CHANGE. Stop supporting Node 4.x.