### PR TITLE
feat: change default target to es2016

### DIFF
--- a/tsconfig-google.json
+++ b/tsconfig-google.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2015"],
+    "lib": ["es2016"],
     "module": "commonjs",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
@@ -14,7 +14,7 @@
     "pretty": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5"
+    "target": "es2016"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
BREAKING CHANGE: since we no longer support Node 4.x, we can default
to the target ES2016.

Fixes: https://github.com/google/ts-style/issues/147