### PR TITLE
chore: release 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gts",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Google TypeScript Style",
   "repository": "google/ts-style",
   "main": "build/src/index.js",


### PR DESCRIPTION
[Release notes](https://github.com/google/ts-style/releases/edit/untagged-34e192980be6eb650e6b)

As it would turn out, clang-format 1.2.2 has a nasty TypeScript formatting bug, and the fix is in 1.2.3.  It's probably time to ship :)