### PR TITLE
feat: generate tslint.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ When you run the `npx gts init` command, it's going to do a few things for you:
   - `compile`: Compiles the source code using TypeScript compiler.
   - `pretest`, `posttest` and `prepare`: convenience integrations.
 
-We strongly recommend you use the default style config, but if you must tweak, you can edit the generated `tsconfig.json`. For linter, we use the default `tslint.json` unless we find that file in your project directory.
-
 ## Individual files
 The commands above will all run in the scope of the current folder.  Some commands can be run on individual files:
 

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -85,7 +85,12 @@ test.serial('init', async t => {
         `npx -p ${stagingPath}/gts.tgz --ignore-existing gts init -n`,
         execOpts);
   }
+
+  // Ensure tsconfig.json got generated.
   fs.accessSync(`${stagingPath}/kitchen/tsconfig.json`);
+
+  // Ensure tslint.json got generated.
+  fs.accessSync(`${stagingPath}/kitchen/tslint.json`);
 
   // Compilation shouldn't have happened. Hence no `build` directory.
   const dirContents = fs.readdirSync(`${stagingPath}/kitchen`);
@@ -129,6 +134,8 @@ test.serial('generated json files should terminate with newline', async t => {
   t.truthy(fs.readFileSync(`${stagingPath}/kitchen/package.json`, 'utf8')
                .endsWith('\n'));
   t.truthy(fs.readFileSync(`${stagingPath}/kitchen/tsconfig.json`, 'utf8')
+               .endsWith('\n'));
+  t.truthy(fs.readFileSync(`${stagingPath}/kitchen/tslint.json`, 'utf8')
                .endsWith('\n'));
 });
 


### PR DESCRIPTION
`init` now generates a tslint.json file which inherits from the default
configuration. This empowers the users to customize if necessary
instead of being overly opinionated.

Fixes: #127
Fixes: #119 

This depends upon #158 and #159, so the first two commits don't need to be reviewed. They will be removed once those PRs land.