### PR TITLE
feat: generate .clang-format

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -18,8 +18,7 @@ import {createProgram} from './lint';
 
 const clangFormat = require('clang-format');
 
-const baseArgs =
-    ['-style', '{Language: JavaScript, BasedOnStyle: Google, ColumnLimit: 80}'];
+const baseArgs = ['-style=file'];
 
 /**
  * Run tslint fix and clang fix with the default configuration

--- a/src/init.ts
+++ b/src/init.ts
@@ -156,6 +156,11 @@ async function generateTsConfig(options: Options): Promise<void> {
   return generateConfigFile(options, './tsconfig.json', config);
 }
 
+async function generateClangFormat(options: Options): Promise<void> {
+  const style = await read(path.join(__dirname, '../../.clang-format'), 'utf8');
+  return generateConfigFile(options, './.clang-format', style);
+}
+
 async function generateConfigFile(
     options: Options, filename: string, contents: string) {
   let existing;
@@ -183,7 +188,7 @@ async function generateConfigFile(
     if (!options.dryRun) {
       await write(filename, contents);
     }
-    options.logger.dir(JSON.parse(contents));
+    options.logger.log(contents);
   }
 }
 
@@ -222,6 +227,7 @@ export async function init(options: Options): Promise<boolean> {
   }
   await generateTsConfig(options);
   await generateTsLintConfig(options);
+  await generateClangFormat(options);
 
   // Run `npm install` after initial setup so `npm run check` works right away.
   if (!options.dryRun) {

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -86,11 +86,10 @@ test.serial('init', async t => {
         execOpts);
   }
 
-  // Ensure tsconfig.json got generated.
+  // Ensure config files got generated.
   fs.accessSync(`${stagingPath}/kitchen/tsconfig.json`);
-
-  // Ensure tslint.json got generated.
   fs.accessSync(`${stagingPath}/kitchen/tslint.json`);
+  fs.accessSync(`${stagingPath}/kitchen/.clang-format`);
 
   // Compilation shouldn't have happened. Hence no `build` directory.
   const dirContents = fs.readdirSync(`${stagingPath}/kitchen`);


### PR DESCRIPTION
`init` now generates a .clang-format file. This allows IDEs to pick up
the config and integrate well with the gts provided style.

Fixes: https://github.com/google/ts-style/issues/120