### PR TITLE
fix: use correct lint config for individual files

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -30,8 +30,8 @@ export function lint(
     options: Options, files: string[] = [], fix = false): boolean {
   const configPath =
       fs.existsSync(path.join(options.targetRootDir, 'tslint.json')) ?
-      path.join(options.targetRootDir, 'tslint.json') :
-      path.join(options.gtsRootDir, 'tslint.json');
+      path.resolve(options.targetRootDir, 'tslint.json') :
+      path.resolve(options.gtsRootDir, 'tslint.json');
 
   const program = createProgram(options);
   const configuration = Configuration.findConfiguration(configPath, '').results;


### PR DESCRIPTION
When invoked with a list of files, linter configuration pertaining to
those files should be preferred rather than the gts default config.