### PR TITLE
fix(format): deal with absent .clang-format

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -37,7 +37,7 @@ export async function format(
     fix = false;
   }
 
-  // If the project has a .clang-format – use it. Else use the default as a
+  // If the project has a .clang-format – use it. Else use the default as an
   // inline argument.
   const baseClangFormatArgs =
       fs.existsSync(path.join(options.targetRootDir, '.clang-format')) ?

--- a/test/test-format.ts
+++ b/test/test-format.ts
@@ -25,8 +25,8 @@ import {nop} from '../src/util';
 import {withFixtures} from './fixtures';
 
 // clang-format won't pass this code because of trailing spaces.
-const BAD_CODE = 'export const foo = 2;  ';
-const GOOD_CODE = 'export const foo = 2;';
+const BAD_CODE = 'export const foo = [ 2 ];';
+const GOOD_CODE = 'export const foo = [2];';
 
 const OPTIONS: Options = {
   gtsRootDir: path.resolve(__dirname, '../..'),
@@ -163,4 +163,15 @@ test.serial('format should not auto fix on dry-run', t => {
             fs.readFileSync(path.join(fixturesDir, 'a.ts'), 'utf8');
         t.deepEqual(contents, BAD_CODE);
       });
+});
+
+test.serial('format should use user provided config', t => {
+  return withFixtures({
+    'tsconfig.json': JSON.stringify({files: ['a.ts']}),
+    '.clang-format': 'Language: JavaScript',
+    'a.ts': BAD_CODE // but actually good under the custom JS format config.
+  }, async () => {
+    const result = await format.format(OPTIONS, [], false);
+    t.true(result);
+  });
 });

--- a/test/test-format.ts
+++ b/test/test-format.ts
@@ -166,12 +166,15 @@ test.serial('format should not auto fix on dry-run', t => {
 });
 
 test.serial('format should use user provided config', t => {
-  return withFixtures({
-    'tsconfig.json': JSON.stringify({files: ['a.ts']}),
-    '.clang-format': 'Language: JavaScript',
-    'a.ts': BAD_CODE // but actually good under the custom JS format config.
-  }, async () => {
-    const result = await format.format(OPTIONS, [], false);
-    t.true(result);
-  });
+  return withFixtures(
+      {
+        'tsconfig.json': JSON.stringify({files: ['a.ts']}),
+        '.clang-format': 'Language: JavaScript',
+        'a.ts':
+            BAD_CODE  // but actually good under the custom JS format config.
+      },
+      async () => {
+        const result = await format.format(OPTIONS, [], false);
+        t.true(result);
+      });
 });


### PR DESCRIPTION
This fixes a regression in v0.7.0.