### PR TITLE
Add more tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -277,9 +277,9 @@
       }
     },
     "@types/inquirer": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.41.tgz",
-      "integrity": "sha512-kIWkK3FECGKt9OrURxRvi59gwMNiWTePXWOvaJn+xhplbEvu91hIDMfLe5PUu+cEEMmD6EFU4VFJJKKp5kzCtw==",
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.42.tgz",
+      "integrity": "sha512-flMaNWU2g9NrtZ4bIV+7SEY2W7OdWNNhmJ0rE1lWVxGrkp3TfFGMcFCxRIBmGWigI8e6n+2HqLjizTTfgcpHLg==",
       "dev": true,
       "requires": {
         "@types/rx": "*",

--- a/src/format.ts
+++ b/src/format.ts
@@ -18,7 +18,8 @@ import * as path from 'path';
 import {Options} from './cli';
 import {createProgram} from './lint';
 
-const clangFormat = require('clang-format');
+// Exported for testing purposes.
+export const clangFormat = require('clang-format');
 
 const BASE_ARGS_FILE = ['-style=file'];
 const BASE_ARGS_INLINE =
@@ -56,7 +57,7 @@ export async function format(
       program.getRootFileNames().filter(f => !f.endsWith('.d.ts'));
 
   if (fix) {
-    return await fixFormat(srcFiles, baseClangFormatArgs);
+    return fixFormat(srcFiles, baseClangFormatArgs);
   } else {
     const result = await checkFormat(srcFiles, baseClangFormatArgs);
     if (!result) {

--- a/src/init.ts
+++ b/src/init.ts
@@ -45,13 +45,13 @@ export interface PackageJson {
   version?: string;
   devDependencies?: Bag<string>;
   scripts?: Bag<string>;
-  name: string;
-  description: string;
-  main: string;
-  types: string;
-  files: string[];
-  license: string;
-  keywords: string[];
+  name?: string;
+  description?: string;
+  main?: string;
+  types?: string;
+  files?: string[];
+  license?: string;
+  keywords?: string[];
 }
 
 async function query(
@@ -72,7 +72,7 @@ async function query(
   return answers.query;
 }
 
-async function addScripts(
+export async function addScripts(
     packageJson: PackageJson, options: Options): Promise<boolean> {
   let edits = false;
   const scripts: Bag<string> = {
@@ -111,7 +111,7 @@ async function addScripts(
   return edits;
 }
 
-async function addDependencies(
+export async function addDependencies(
     packageJson: PackageJson, options: Options): Promise<boolean> {
   let edits = false;
   const deps: Bag<string> = {'gts': `^${pkg.version}`, 'typescript': '~2.8.0'};

--- a/test/test-init.ts
+++ b/test/test-init.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'ava';
+import path from 'path';
+
+import {Options} from '../src/cli';
+import * as init from '../src/init';
+import {nop} from '../src/util';
+import {withFixtures} from './fixtures';
+
+const OPTIONS: Options = {
+  gtsRootDir: path.resolve(__dirname, '../..'),
+  targetRootDir: './',
+  dryRun: false,
+  yes: false,
+  no: false,
+  logger: {log: nop, error: nop, dir: nop}
+};
+
+test('addScripts should add a scripts section if none exists', async t => {
+  const pkg: init.PackageJson = {};
+  const result = await init.addScripts(pkg, OPTIONS);
+  t.is(result, true);  // made edits.
+  t.truthy(pkg.scripts);
+  ['check', 'clean', 'compile', 'fix', 'prepare', 'pretest', 'posttest']
+      .forEach(s => {
+        t.truthy(pkg.scripts![s]);
+      });
+});
+
+test('addScripts should not edit existing scripts on no', async t => {
+  const SCRIPTS = {
+    check: `fake check`,
+    clean: 'fake clean',
+    compile: `fake tsc -p .`,
+    fix: `fake fix`,
+    prepare: `fake run compile`,
+    pretest: `fake run compile`,
+    posttest: `fake run check`
+  };
+  const pkg: init.PackageJson = {scripts: Object.assign({}, SCRIPTS)};
+  const optionsWithNo = Object.assign({}, OPTIONS, {no: true});
+  const result = await init.addScripts(pkg, optionsWithNo);
+  t.is(result, false);  // no edits.
+  t.deepEqual(pkg.scripts, SCRIPTS);
+});
+
+test('addScripts should edit existing scripts on yes', async t => {
+  const SCRIPTS = {
+    check: `fake check`,
+    clean: 'fake clean',
+    compile: `fake tsc -p .`,
+    fix: `fake fix`,
+    prepare: `fake run compile`,
+    pretest: `fake run compile`,
+    posttest: `fake run check`
+  };
+  const pkg: init.PackageJson = {scripts: Object.assign({}, SCRIPTS)};
+  const optionsWithYes = Object.assign({}, OPTIONS, {yes: true});
+  const result = await init.addScripts(pkg, optionsWithYes);
+  t.is(result, true);  // made edits.
+  t.notDeepEqual(pkg.scripts, SCRIPTS);
+});
+
+test('addDependencies should add a deps section if none exists', async t => {
+  const pkg: init.PackageJson = {};
+  const result = await init.addDependencies(pkg, OPTIONS);
+  t.is(result, true);  // made edits.
+  t.truthy(pkg.devDependencies);
+});
+
+test('addDependencies should not edit existing deps on no', async t => {
+  const DEPS = {gts: 'something', typescript: 'or the other'};
+  const pkg: init.PackageJson = {devDependencies: Object.assign({}, DEPS)};
+  const optionsWithNo = Object.assign({}, OPTIONS, {no: true});
+  const result = await init.addDependencies(pkg, optionsWithNo);
+  t.is(result, false);  // no edits.
+  t.deepEqual(pkg.devDependencies, DEPS);
+});
+
+test('addDependencies should edit existing deps on yes', async t => {
+  const DEPS = {gts: 'something', typescript: 'or the other'};
+  const pkg: init.PackageJson = {devDependencies: Object.assign({}, DEPS)};
+  const optionsWithYes = Object.assign({}, OPTIONS, {yes: true});
+  const result = await init.addDependencies(pkg, optionsWithYes);
+  t.is(result, true);  // made edits.
+  t.notDeepEqual(pkg.devDependencies, DEPS);
+});
+
+// TODO: this test has not been completed yet.
+// test.serial('init should read local package.json', t => {
+//   return withFixtures(
+//       {'package.json': JSON.stringify({some: 'property'})}, async () => {
+//         const optionsWithDryRun = Object.assign({}, OPTIONS, {dryRun: true});
+//         const result = await init.init(optionsWithDryRun);
+//         t.truthy(result);
+//       });
+// });
+
+// TODO: need more tests.

--- a/test/test-init.ts
+++ b/test/test-init.ts
@@ -19,7 +19,8 @@ import path from 'path';
 
 import {Options} from '../src/cli';
 import * as init from '../src/init';
-import {nop} from '../src/util';
+import {nop, readJsonp as readJson} from '../src/util';
+
 import {withFixtures} from './fixtures';
 
 const OPTIONS: Options = {
@@ -30,16 +31,27 @@ const OPTIONS: Options = {
   no: false,
   logger: {log: nop, error: nop, dir: nop}
 };
+const OPTIONS_YES = Object.assign({}, OPTIONS, {yes: true});
+const OPTIONS_NO = Object.assign({}, OPTIONS, {no: true});
+const OPTIONS_DRY_RUN = Object.assign({}, OPTIONS, {dryRun: true});
+
+function hasExpectedScripts(packageJson: init.PackageJson): boolean {
+  return !!packageJson.scripts && [
+    'check', 'clean', 'compile', 'fix', 'prepare', 'pretest', 'posttest'
+  ].every(s => !!packageJson.scripts![s]);
+}
+
+function hasExpectedDependencies(packageJson: init.PackageJson): boolean {
+  return !!packageJson.devDependencies &&
+      ['gts', 'typescript'].every(d => !!packageJson.devDependencies![d]);
+}
 
 test('addScripts should add a scripts section if none exists', async t => {
   const pkg: init.PackageJson = {};
   const result = await init.addScripts(pkg, OPTIONS);
   t.is(result, true);  // made edits.
   t.truthy(pkg.scripts);
-  ['check', 'clean', 'compile', 'fix', 'prepare', 'pretest', 'posttest']
-      .forEach(s => {
-        t.truthy(pkg.scripts![s]);
-      });
+  t.truthy(hasExpectedScripts(pkg));
 });
 
 test('addScripts should not edit existing scripts on no', async t => {
@@ -53,8 +65,8 @@ test('addScripts should not edit existing scripts on no', async t => {
     posttest: `fake run check`
   };
   const pkg: init.PackageJson = {scripts: Object.assign({}, SCRIPTS)};
-  const optionsWithNo = Object.assign({}, OPTIONS, {no: true});
-  const result = await init.addScripts(pkg, optionsWithNo);
+
+  const result = await init.addScripts(pkg, OPTIONS_NO);
   t.is(result, false);  // no edits.
   t.deepEqual(pkg.scripts, SCRIPTS);
 });
@@ -70,8 +82,7 @@ test('addScripts should edit existing scripts on yes', async t => {
     posttest: `fake run check`
   };
   const pkg: init.PackageJson = {scripts: Object.assign({}, SCRIPTS)};
-  const optionsWithYes = Object.assign({}, OPTIONS, {yes: true});
-  const result = await init.addScripts(pkg, optionsWithYes);
+  const result = await init.addScripts(pkg, OPTIONS_YES);
   t.is(result, true);  // made edits.
   t.notDeepEqual(pkg.scripts, SCRIPTS);
 });
@@ -86,8 +97,8 @@ test('addDependencies should add a deps section if none exists', async t => {
 test('addDependencies should not edit existing deps on no', async t => {
   const DEPS = {gts: 'something', typescript: 'or the other'};
   const pkg: init.PackageJson = {devDependencies: Object.assign({}, DEPS)};
-  const optionsWithNo = Object.assign({}, OPTIONS, {no: true});
-  const result = await init.addDependencies(pkg, optionsWithNo);
+  const OPTIONS_NO = Object.assign({}, OPTIONS, {no: true});
+  const result = await init.addDependencies(pkg, OPTIONS_NO);
   t.is(result, false);  // no edits.
   t.deepEqual(pkg.devDependencies, DEPS);
 });
@@ -95,20 +106,45 @@ test('addDependencies should not edit existing deps on no', async t => {
 test('addDependencies should edit existing deps on yes', async t => {
   const DEPS = {gts: 'something', typescript: 'or the other'};
   const pkg: init.PackageJson = {devDependencies: Object.assign({}, DEPS)};
-  const optionsWithYes = Object.assign({}, OPTIONS, {yes: true});
-  const result = await init.addDependencies(pkg, optionsWithYes);
+
+  const result = await init.addDependencies(pkg, OPTIONS_YES);
   t.is(result, true);  // made edits.
   t.notDeepEqual(pkg.devDependencies, DEPS);
 });
 
-// TODO: this test has not been completed yet.
-// test.serial('init should read local package.json', t => {
-//   return withFixtures(
-//       {'package.json': JSON.stringify({some: 'property'})}, async () => {
-//         const optionsWithDryRun = Object.assign({}, OPTIONS, {dryRun: true});
-//         const result = await init.init(optionsWithDryRun);
-//         t.truthy(result);
-//       });
-// });
+// TODO: test generateConfigFile
+
+// init
+test.serial('init should read local package.json', t => {
+  const originalContents = {some: 'property'};
+  return withFixtures(
+      {'package.json': JSON.stringify(originalContents)}, async () => {
+        // TODO: this test causes `npm install` to run in the fixture directory.
+        // This may make it sensistive to the network, npm resiliency. Find a
+        // way to mock npm.
+        const result = await init.init(OPTIONS_YES);
+        t.truthy(result);
+        const contents = await readJson('./package.json');
+
+        t.not(contents, originalContents, 'the file should have been modified');
+        t.is(
+            contents.some, originalContents.some,
+            'unrelated property should have preserved');
+      });
+});
+
+test.serial('init should handle missing package.json', t => {
+  return withFixtures({}, async () => {
+    // TODO: this test causes `npm install` to run in the fixture directory.
+    // This may make it sensistive to the network, npm resiliency. Find a way to
+    // mock npm.
+    const result = await init.init(OPTIONS_YES);
+    t.truthy(result);
+    const contents = await readJson('./package.json');
+    t.truthy(hasExpectedScripts(contents));
+    t.truthy(hasExpectedDependencies(contents));
+  });
+});
+
 
 // TODO: need more tests.


### PR DESCRIPTION
In an effort to improve coverage, I started working some tests. It turns out that our current coverage numbers are a lie as `init.ts` wasn't accounted for. It only gets tested via `test-kitchen.ts` which is hard to report for coverage purposes (it uses an tarball-installed version of the package rather than the existing files).

Here some more tests. Still more to come, but no reason to sit on these. These can land.