### PR TITLE
fix: disable esModuleInterop

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 import * as path from 'path';
-import meow from 'meow';
-import updateNotifier from 'update-notifier';
+import * as meow from 'meow';
+import * as updateNotifier from 'update-notifier';
 import {init} from './init';
 import {clean} from './clean';
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,8 +16,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import pify from 'pify';
-import rimraf from 'rimraf';
+import * as pify from 'pify';
+import * as rimraf from 'rimraf';
 
 export const readFilep = pify(fs.readFile);
 export const rimrafp = pify(rimraf);

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -16,9 +16,9 @@
 
 import {test, Test} from 'ava';
 import * as fs from 'fs';
-import makeDir from 'make-dir';
+import * as makeDir from 'make-dir';
 import * as path from 'path';
-import pify from 'pify';
+import * as pify from 'pify';
 import * as tmp from 'tmp';
 
 const writeFilep = pify(fs.writeFile);

--- a/test/test-format.ts
+++ b/test/test-format.ts
@@ -15,7 +15,7 @@
  */
 
 import test from 'ava';
-import fs from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 
 import {Options} from '../src/cli';

--- a/test/test-init.ts
+++ b/test/test-init.ts
@@ -15,7 +15,7 @@
  */
 
 import test from 'ava';
-import path from 'path';
+import * as path from 'path';
 
 import {Options} from '../src/cli';
 import * as init from '../src/init';

--- a/test/test-kitchen.ts
+++ b/test/test-kitchen.ts
@@ -4,8 +4,8 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as ncp from 'ncp';
 import * as path from 'path';
-import pify from 'pify';
-import rimraf from 'rimraf';
+import * as pify from 'pify';
+import * as rimraf from 'rimraf';
 import * as tmp from 'tmp';
 
 interface ExecResult {

--- a/test/test-lint.ts
+++ b/test/test-lint.ts
@@ -15,7 +15,7 @@
  */
 
 import test from 'ava';
-import fs from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 
 import {Options} from '../src/cli';

--- a/tsconfig-google.json
+++ b/tsconfig-google.json
@@ -4,7 +4,6 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "declaration": true,
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2016"],
     "module": "commonjs",


### PR DESCRIPTION
BREAKING CHANGE: esModuleInterop causes synthetic imports to leak from
libraries to their users. Users must compile with allowSyntheticImports
as well if they use a library that uses this flag.

This has been causing a lot of churn in libraries that use gts.