### PR TITLE
fix: allow 'gts clean' to follow tsconfig.json dependency chain

### DIFF
--- a/src/clean.ts
+++ b/src/clean.ts
@@ -30,7 +30,6 @@ export async function clean(options: Options): Promise<boolean> {
   const tsconfig = (await getTSConfig(options.targetRootDir)) as TSConfig;
   if (tsconfig.compilerOptions && tsconfig.compilerOptions.outDir) {
     const outDir = tsconfig.compilerOptions.outDir;
-
     if (outDir === '.') {
       options.logger.error(
           `${chalk.red('ERROR:')} ${chalk.gray('compilerOptions.outDir')} ` +

--- a/src/clean.ts
+++ b/src/clean.ts
@@ -30,6 +30,7 @@ export async function clean(options: Options): Promise<boolean> {
   const tsconfig = (await getTSConfig(options.targetRootDir)) as TSConfig;
   if (tsconfig.compilerOptions && tsconfig.compilerOptions.outDir) {
     const outDir = tsconfig.compilerOptions.outDir;
+
     if (outDir === '.') {
       options.logger.error(
           `${chalk.red('ERROR:')} ${chalk.gray('compilerOptions.outDir')} ` +

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,37 +13,104 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+ 
 import * as fs from 'fs';
 import * as path from 'path';
 import pify from 'pify';
 import rimraf from 'rimraf';
-
+ 
 export const readFilep = pify(fs.readFile);
 export const rimrafp = pify(rimraf);
 export const writeFileAtomicp = pify(require('write-file-atomic'));
-
+ 
 export async function readJsonp(jsonPath: string) {
   return JSON.parse(await readFilep(jsonPath));
 }
-
+ 
 export interface ReadFileP {
-  (path: string, encoding: string): Promise<string>;
+  (path: string, encoding: string): Promise < string > ;
 }
-
+ 
 export function nop() {
   /* empty */
 }
-
+ 
 /**
  * Find the tsconfig.json, read it, and return parsed contents.
  * @param rootDir Directory where the tsconfig.json should be found.
  */
+
+ // Old getTSConfig function
+// export async function getTSConfig(
+//   rootDir: string, customReadFilep ? : ReadFileP): Promise < {} > {
+//   const tsconfigPath = path.join(rootDir, 'tsconfig.json');
+//   //console.log(tsconfigPath);
+//   customReadFilep = customReadFilep || readFilep;
+//   const json = await customReadFilep(tsconfigPath, 'utf8');
+//   console.log(json);
+//   const contents = JSON.parse(json);
+//   return contents;
+// }
+ 
 export async function getTSConfig(
-    rootDir: string, customReadFilep?: ReadFileP): Promise<{}> {
+  rootDir: string, customReadFilep ? : ReadFileP): Promise < {} > {
+ 
   const tsconfigPath = path.join(rootDir, 'tsconfig.json');
+
+  //console.log(tsconfigPath);
   customReadFilep = customReadFilep || readFilep;
   const json = await customReadFilep(tsconfigPath, 'utf8');
-  const contents = JSON.parse(json);
+  //console.log(json);
+  let contents = JSON.parse(json);
+
+  if (contents["extends"]) {
+    const thing = await getExtension(contents["extends"]);
+    contents =combineTSConfig(thing, contents);
+ 
+  }
   return contents;
 }
+ 
+
+async function getExtension(
+  filePath: string, customReadFilep ? : ReadFileP): Promise < {} > {
+  customReadFilep = customReadFilep || readFilep;
+  const json = await customReadFilep(filePath, 'utf8');
+  let contents = JSON.parse(json);
+ 
+  if (contents["extends"]) {
+    const nextFile = await getExtension(contents["extends"]);
+    contents =combineTSConfig(nextFile, contents);
+  }
+  //console.log(contents);
+  return contents;
+ 
+}
+ 
+function combineTSConfig(
+ ts1: any, ts2: any): {}{
+// const TSProperties = ["compilerOptions", "files", "include", "exclude"];
+let result = {"compilerOptions" : {},
+  "files": [],
+  "include":[],
+  "exclude": []
+};
+
+
+ts1.compilerOptions = ts1.compilerOptions || {};
+ts1.files = ts1.files || [];
+ts1.include = ts1.include || [];
+ts1.exclude = ts1.exclude || [];
+ts2.compilerOptions = ts2.compilerOptions || {};
+ts2.files = ts2.files || [];
+ts2.include = ts2.include || [];
+ts2.exclude = ts2.exclude || [];
+
+
+Object.assign(result.compilerOptions, ts1.compilerOptions, ts2.compilerOptions);
+result.files = result.files.concat(ts1.files, ts2.files);
+result.include = result.include.concat(ts1.include, ts2.include);
+result.exclude = result.exclude.concat(ts1.exclude, ts2.exclude);
+
+return result;
+ }

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,7 +51,12 @@ export function nop() {
 //   const contents = JSON.parse(json);
 //   return contents;
 // }
- 
+ interface configFile {
+   files: string[],
+   compilerOptions: {},
+   include: string[],
+   exclude: string[]
+ }
 export async function getTSConfig(
   rootDir: string, customReadFilep ? : ReadFileP): Promise < {} > {
  
@@ -87,8 +92,9 @@ async function getExtension(
  
 }
  
+// the inherited config file overwrites the base config file's "files", "include", and "exclude" fields and combines compiler options
 function combineTSConfig(
- ts1: any, ts2: any): {}{
+ base: any, inherited: any): {}{
 // const TSProperties = ["compilerOptions", "files", "include", "exclude"];
 let result = {"compilerOptions" : {},
   "files": [],
@@ -97,20 +103,20 @@ let result = {"compilerOptions" : {},
 };
 
 
-ts1.compilerOptions = ts1.compilerOptions || {};
-ts1.files = ts1.files || [];
-ts1.include = ts1.include || [];
-ts1.exclude = ts1.exclude || [];
+base.compilerOptions = base.compilerOptions || {};
+base.files = base.files || [];
+base.include = base.include || [];
+base.exclude = base.exclude || [];
 ts2.compilerOptions = ts2.compilerOptions || {};
 ts2.files = ts2.files || [];
 ts2.include = ts2.include || [];
 ts2.exclude = ts2.exclude || [];
 
 
-Object.assign(result.compilerOptions, ts1.compilerOptions, ts2.compilerOptions);
-result.files = result.files.concat(ts1.files, ts2.files);
-result.include = result.include.concat(ts1.include, ts2.include);
-result.exclude = result.exclude.concat(ts1.exclude, ts2.exclude);
+Object.assign(result.compilerOptions, base.compilerOptions, ts2.compilerOptions);
+result.files = inherited.files || base.files
+result.include = inherited.files || base.files
+result.exclude = inherited.files || base.files
 
 return result;
  }

--- a/src/util.ts
+++ b/src/util.ts
@@ -39,12 +39,13 @@ export function nop() {
  * Find the tsconfig.json, read it, and return parsed contents.
  * @param rootDir Directory where the tsconfig.json should be found.
  * If the tsconfig.json file has an "extends" field hop down the dependency tree
- * until it ends or a circular reference is found in which case an error will be thrown
+ * until it ends or a circular reference is found in which case an error will be
+ * thrown
  */
 export async function getTSConfig(
     rootDir: string, customReadFilep?: ReadFileP): Promise<ConfigFile> {
   customReadFilep = customReadFilep || readFilep;
-  const readArr = [''];
+  const readArr = new Set();
   return await getBase('tsconfig.json', customReadFilep, readArr, rootDir);
 }
 
@@ -58,16 +59,16 @@ export async function getTSConfig(
  * returns a ConfigFile object containing the data from all the dependencies
  */
 async function getBase(
-    filePath: string, customReadFilep: ReadFileP, readFiles: string[],
+    filePath: string, customReadFilep: ReadFileP, readFiles: Set<string>,
     currentDir: string): Promise<ConfigFile> {
   customReadFilep = customReadFilep || readFilep;
 
   filePath = path.resolve(currentDir, filePath);
 
-  if (readFiles.indexOf(filePath) !== -1) {
+  if (readFiles.has(filePath)) {
     throw new Error('Circular reference in ${filePath}');
   }
-  readFiles.push(filePath);
+  readFiles.add(filePath);
 
   const json = await customReadFilep(filePath, 'utf8');
   let contents = JSON.parse(json);
@@ -105,4 +106,3 @@ export interface ConfigFile {
   include?: string[];
   exclude?: string[];
 }
- 

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,7 +19,6 @@ import * as path from 'path';
 import pify from 'pify';
 import rimraf from 'rimraf';
 
-
 export const readFilep = pify(fs.readFile);
 export const rimrafp = pify(rimraf);
 export const writeFileAtomicp = pify(require('write-file-atomic'));
@@ -40,13 +39,11 @@ export function nop() {
  * Find the tsconfig.json, read it, and return parsed contents.
  * @param rootDir Directory where the tsconfig.json should be found.
  * If the tsconfig.json file has an "extends" field hop down the dependency tree
- * until it ends
+ * until it ends or a circular reference is found in which case an error will be thrown
  */
-
 export async function getTSConfig(
     rootDir: string, customReadFilep?: ReadFileP): Promise<ConfigFile> {
   customReadFilep = customReadFilep || readFilep;
-  // array to hold accessed files, used to check for circular references
   const readArr = [''];
   return await getBase('tsconfig.json', customReadFilep, readArr, rootDir);
 }
@@ -55,10 +52,10 @@ export async function getTSConfig(
  * Recursively iterate through the dependency chain until we reach the end of
  * the dependency chain or encounter a circular reference
  * @param filePath Filepath of file currently being read
- * @param customReadFilep the file reading function being used
+ * @param customReadFilep The file reading function being used
  * @param readFiles an array of the previously read files so we can check for
- * circular references returns a ConfigFile object containing the data from all
- * the dependencies
+ * circular references
+ * returns a ConfigFile object containing the data from all the dependencies
  */
 async function getBase(
     filePath: string, customReadFilep: ReadFileP, readFiles: string[],

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import pify from 'pify';
 import rimraf from 'rimraf';
-import {file} from 'tmp';
+
 
 export const readFilep = pify(fs.readFile);
 export const rimrafp = pify(rimraf);

--- a/src/util.ts
+++ b/src/util.ts
@@ -65,7 +65,7 @@ async function getBase(
 
   filePath = path.resolve(currentDir, filePath);
 
-  // An error is thrown if there is a circular reference as specified by the TypeScript doc
+  // An error is thrown if there is a circular reference as specified by the TypeScript
   if (readFiles.has(filePath)) {
     throw new Error('Circular reference in ${filePath}');
   }
@@ -89,7 +89,7 @@ async function getBase(
  * @param inherited is then loaded and overwrites base
  */
 function combineTSConfig(base: ConfigFile, inherited: ConfigFile): ConfigFile {
-  const result: ConfigFile = {'compilerOptions': {}};
+  const result: ConfigFile = {compilerOptions: {}};
 
   Object.assign(result, base, inherited);
   Object.assign(

--- a/src/util.ts
+++ b/src/util.ts
@@ -71,17 +71,20 @@ async function getBase(
     throw new Error(`Circular reference in ${filePath}`);
   }
   readFiles.add(filePath);
+  try {
+    const json = await customReadFilep(filePath, 'utf8');
+    let contents = JSON.parse(json);
 
-  const json = await customReadFilep(filePath, 'utf8');
-  let contents = JSON.parse(json);
+    if (contents.extends) {
+      const nextFile = await getBase(
+          contents.extends, customReadFilep, readFiles, path.dirname(filePath));
+      contents = combineTSConfig(nextFile, contents);
+    }
 
-  if (contents.extends) {
-    const nextFile = await getBase(contents.extends, customReadFilep, readFiles,
-                                                   path.dirname(filePath));
-    contents = combineTSConfig(nextFile, contents);
+    return contents;
+  } catch (err) {
+    throw new Error(`${filePath} Not Found`);
   }
-
-  return contents;
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -105,3 +105,4 @@ export interface ConfigFile {
   include?: string[];
   exclude?: string[];
 }
+

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,7 +68,7 @@ async function getBase(
   // An error is thrown if there is a circular reference as specified by the
   // TypeScript doc
   if (readFiles.has(filePath)) {
-    throw new Error('Circular reference in ${filePath}');
+    throw new Error(`Circular reference in ${filePath}`);
   }
   readFiles.add(filePath);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,8 +47,8 @@ export async function getTSConfig(
   const readArr = [''];
   return await getBase('tsconfig.json', customReadFilep, readArr, rootDir);
 }
+
 /**
- *
  * Recursively iterate through the dependency chain until we reach the end of
  * the dependency chain or encounter a circular reference
  * @param filePath Filepath of file currently being read
@@ -95,6 +95,7 @@ function combineTSConfig(base: ConfigFile, inherited: ConfigFile): ConfigFile {
   delete result.extends;
   return result;
 }
+
 /**
  * An interface containing the high level data fields present in Config Files
  */

--- a/src/util.ts
+++ b/src/util.ts
@@ -83,7 +83,7 @@ async function getBase(
 }
 
 /**
- * takes in 2 config files
+ * Takes in 2 config files
  * @param base is loaded first
  * @param inherited is then loaded and overwrites base
  */

--- a/src/util.ts
+++ b/src/util.ts
@@ -64,8 +64,8 @@ async function getBase(
     filePath: string, customReadFilep: ReadFileP, readFiles: string[],
     currentDir: string): Promise<ConfigFile> {
   customReadFilep = customReadFilep || readFilep;
-  
-  filePath = path.resolve(currentDir, filePath)
+
+  filePath = path.resolve(currentDir, filePath);
 
   if (readFiles.indexOf(filePath) !== -1) {
     throw new Error(
@@ -77,8 +77,8 @@ async function getBase(
   let contents = JSON.parse(json);
 
   if (contents.extends) {
-    const nextFile =
-        await getBase(contents.extends, customReadFilep, readFiles, path.dirname(filePath));
+    const nextFile = await getBase(contents.extends, customReadFilep, readFiles,
+                                                   path.dirname(filePath));
     contents = combineTSConfig(nextFile, contents);
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -88,7 +88,7 @@ async function getBase(
  * @param inherited is then loaded and overwrites base
  */
 function combineTSConfig(base: ConfigFile, inherited: ConfigFile): ConfigFile {
-  const result = {'compilerOptions': {}, 'extends': {}};
+  const result: ConfigFile = {'compilerOptions': {}};
 
   Object.assign(result, base, inherited);
   Object.assign(
@@ -105,4 +105,5 @@ export interface ConfigFile {
   compilerOptions?: {};
   include?: string[];
   exclude?: string[];
+  extends?: string[];
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,8 +68,7 @@ async function getBase(
   filePath = path.resolve(currentDir, filePath);
 
   if (readFiles.indexOf(filePath) !== -1) {
-    throw new Error(
-        'Circular reference in ' + readFiles[readFiles.indexOf(filePath)]);
+    throw new Error('Circular reference in ${filePath}');
   }
   readFiles.push(filePath);
 
@@ -102,7 +101,6 @@ function combineTSConfig(base: ConfigFile, inherited: ConfigFile): ConfigFile {
 /**
  * An interface containing the high level data fields present in Config Files
  */
-
 export interface ConfigFile {
   files?: string[];
   compilerOptions?: {};

--- a/src/util.ts
+++ b/src/util.ts
@@ -39,7 +39,8 @@ export function nop() {
 /**
  * Find the tsconfig.json, read it, and return parsed contents.
  * @param rootDir Directory where the tsconfig.json should be found.
- * If the tsconfig.json file has an "extends" field hop down the dependency tree until it ends
+ * If the tsconfig.json file has an "extends" field hop down the dependency tree
+ * until it ends
  */
 
 
@@ -91,14 +92,14 @@ async function getExtension(
         await getExtension(contents['extends'], customReadFilep, readFiles);
     contents = combineTSConfig(nextFile, contents);
   }
-  // console.log(contents);
+
   return Promise.resolve(contents);
 }
 
 // the inherited config file overwrites the base config file's "files",
 // "include", and "exclude" fields and combines compiler options
+
 function combineTSConfig(base: ConfigFile, inherited: ConfigFile): ConfigFile {
-  // const TSProperties = ["compilerOptions", "files", "include", "exclude"];
   const result = {
     'compilerOptions': {},
     'files': [],

--- a/src/util.ts
+++ b/src/util.ts
@@ -65,7 +65,8 @@ async function getBase(
 
   filePath = path.resolve(currentDir, filePath);
 
-  // An error is thrown if there is a circular reference as specified by the TypeScript doc
+  // An error is thrown if there is a circular reference as specified by the
+  // TypeScript doc
   if (readFiles.has(filePath)) {
     throw new Error('Circular reference in ${filePath}');
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,10 +62,9 @@ export async function getTSConfig(
  
   const tsconfigPath = path.join(rootDir, 'tsconfig.json');
 
-  //console.log(tsconfigPath);
+  
   customReadFilep = customReadFilep || readFilep;
   const json = await customReadFilep(tsconfigPath, 'utf8');
-  //console.log(json);
   let contents = JSON.parse(json);
 
   if (contents["extends"]) {
@@ -103,17 +102,9 @@ let result = {"compilerOptions" : {},
 };
 
 
-base.compilerOptions = base.compilerOptions || {};
-base.files = base.files || [];
-base.include = base.include || [];
-base.exclude = base.exclude || [];
-ts2.compilerOptions = ts2.compilerOptions || {};
-ts2.files = ts2.files || [];
-ts2.include = ts2.include || [];
-ts2.exclude = ts2.exclude || [];
 
 
-Object.assign(result.compilerOptions, base.compilerOptions, ts2.compilerOptions);
+Object.assign(result.compilerOptions, base.compilerOptions, inherited.compilerOptions);
 result.files = inherited.files || base.files
 result.include = inherited.files || base.files
 result.exclude = inherited.files || base.files

--- a/src/util.ts
+++ b/src/util.ts
@@ -105,4 +105,4 @@ export interface ConfigFile {
   include?: string[];
   exclude?: string[];
 }
-
+ 

--- a/src/util.ts
+++ b/src/util.ts
@@ -65,6 +65,7 @@ async function getBase(
 
   filePath = path.resolve(currentDir, filePath);
 
+  // An error is thrown if there is a circular reference as specified by the TypeScript doc
   if (readFiles.has(filePath)) {
     throw new Error('Circular reference in ${filePath}');
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,9 +62,10 @@ export async function getTSConfig(
  */
 async function getBase(
     filePath: string, customReadFilep: ReadFileP, readFiles: string[],
-    rootDir: string): Promise<ConfigFile> {
+    currentDir: string): Promise<ConfigFile> {
   customReadFilep = customReadFilep || readFilep;
-  filePath = path.resolve(rootDir, filePath)
+  
+  filePath = path.resolve(currentDir, filePath)
 
   if (readFiles.indexOf(filePath) !== -1) {
     throw new Error(
@@ -77,7 +78,7 @@ async function getBase(
 
   if (contents.extends) {
     const nextFile =
-        await getBase(contents.extends, customReadFilep, readFiles, rootDir);
+        await getBase(contents.extends, customReadFilep, readFiles, path.dirname(filePath));
     contents = combineTSConfig(nextFile, contents);
   }
 
@@ -99,9 +100,7 @@ function combineTSConfig(base: ConfigFile, inherited: ConfigFile): ConfigFile {
   return result;
 }
 /**
- * An interface containing the datafields of our tsconfig objects
- * These are the top level properties that are combined/overwritten by
- * dependencies.
+ * An interface containing the high level data fields present in Config Files
  */
 
 export interface ConfigFile {

--- a/src/util.ts
+++ b/src/util.ts
@@ -39,19 +39,10 @@ export function nop() {
 /**
  * Find the tsconfig.json, read it, and return parsed contents.
  * @param rootDir Directory where the tsconfig.json should be found.
+ * If the tsconfig.json file has an "extends" field hop down the dependency tree until it ends
  */
 
-// Old getTSConfig function
-// export async function getTSConfig(
-//   rootDir: string, customReadFilep ? : ReadFileP): Promise < {} > {
-//   const tsconfigPath = path.join(rootDir, 'tsconfig.json');
-//   //console.log(tsconfigPath);
-//   customReadFilep = customReadFilep || readFilep;
-//   const json = await customReadFilep(tsconfigPath, 'utf8');
-//   console.log(json);
-//   const contents = JSON.parse(json);
-//   return contents;
-// }
+
 export interface ConfigFile {
   files?: string[];
   compilerOptions?: {};
@@ -116,17 +107,6 @@ function combineTSConfig(base: ConfigFile, inherited: ConfigFile): ConfigFile {
     'extends': {}
   };
 
-
-
-  /* From the javascript doc
-   *  "Properties in the target object will be overwritten by properties in the
-   * sources if they have the same key. Later sources' properties will similarly
-   * overwrite earlier ones." first overwrite the result file and then merge the
-   * compiler options for more information:
-   *  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-   *  https://www.typescriptlang.org/docs/handbook/tsconfig-json.html
-   *
-   */
   Object.assign(result, base, inherited);
   Object.assign(
       result.compilerOptions, base.compilerOptions, inherited.compilerOptions);

--- a/src/util.ts
+++ b/src/util.ts
@@ -65,7 +65,7 @@ async function getBase(
 
   filePath = path.resolve(currentDir, filePath);
 
-  // An error is thrown if there is a circular reference as specified by the TypeScript
+  // An error is thrown if there is a circular reference as specified by the TypeScript doc
   if (readFiles.has(filePath)) {
     throw new Error('Circular reference in ${filePath}');
   }
@@ -99,7 +99,7 @@ function combineTSConfig(base: ConfigFile, inherited: ConfigFile): ConfigFile {
 }
 
 /**
- * An interface containing the high level data fields present in Config Files
+ * An interface containing the top level data fields present in Config Files
  */
 export interface ConfigFile {
   files?: string[];

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -18,15 +18,11 @@ import * as path from 'path';
 
 import {ConfigFile, getTSConfig} from '../src/util';
 
-
-
 /**
  * Creates a fake promisified readFile function from a map
  * @param myMap contains a filepath as the key and a ConfigFile object as the
- * value. The fake promisified readFile function has the same interface of
- * fs.readFile and takes in a
- * @param configPath and returns a corresponding ConfigFile object or throws an
- * error if the file is not found
+ * value. 
+ * The returned funciton has the same interface as fs.readFile
  */
 function createFakeReadFilep(myMap: Map<string, ConfigFile>) {
   return (configPath: string) => {

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -176,6 +176,5 @@ test(
       t.deepEqual(contents, combinedConfig);
     });
 
-
-
 // TODO: test errors in readFile, JSON.parse.
+ 

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -21,11 +21,12 @@ import {ConfigFile, getTSConfig} from '../src/util';
 
 
 /**
- * Creates a FakeReadFilep function from a map
+ * Creates a fake promisified readFile function from a map
  * @param myMap contains a filepath as the key and a ConfigFile object as the
- * value The FakeReadFilep function takes in a @param configPath and returns a
- * corresponding ConfigFile object or throws an error if the file is not found
- * in the map
+ * value. The fake promisified readFile function has the same interface of
+ * fs.readFile and takes in a
+ * @param configPath and returns a corresponding ConfigFile object or throws an
+ * error if the file is not found
  */
 function createFakeReadFilep(myMap: Map<string, ConfigFile>) {
   return (configPath: string) => {
@@ -133,4 +134,3 @@ test(
 
 
 // TODO: test errors in readFile, JSON.parse.
- 

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -43,7 +43,7 @@ test('should throw an error if it finds a circular reference', async t => {
 
   function fakeReadFilep(
       configPath: string, encoding: string): Promise<string> {
-    let configFile = myMap.get(configPath);
+    const configFile = myMap.get(configPath);
     if (configFile) {
       return Promise.resolve(JSON.stringify(configFile));
     } else {
@@ -79,7 +79,7 @@ test('should follow dependency chain caused by extends files', async t => {
 
   function fakeReadFilep(
       configPath: string, encoding: string): Promise<string> {
-    let configFile = myMap.get(configPath);
+    const configFile = myMap.get(configPath);
     if (configFile) {
       return Promise.resolve(JSON.stringify(configFile));
     } else {
@@ -106,7 +106,7 @@ test(
 
       function fakeReadFilep(
           configPath: string, encoding: string): Promise<string> {
-        let configFile = myMap.get(configPath);
+        const configFile = myMap.get(configPath);
         if (configFile) {
           return Promise.resolve(JSON.stringify(configFile));
         } else {
@@ -133,7 +133,7 @@ test(
 
       function fakeReadFilep(
           configPath: string, encoding: string): Promise<string> {
-        let configFile = myMap.get(configPath);
+        const configFile = myMap.get(configPath);
         if (configFile) {
           return Promise.resolve(JSON.stringify(configFile));
         } else {

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -121,7 +121,7 @@ test(
     });
 
 test(
-    'When reading a file, all filepaths should be relative to the config file currently being read',
+    'when reading a file, all filepaths should be relative to the config file currently being read',
     async t => {
       const FAKE_DIRECTORY = '/some/fake/directory';
       const FAKE_CONFIG1 = {files: ['b'], extends: './foo/FAKE_CONFIG2'};

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -39,7 +39,7 @@ test('should throw an error if it finds a circular reference', async t => {
   function fakeReadFilep(
       configPath: string, encoding: string): Promise<string> {
     switch (configPath) {
-      case '/some/fake/directory/FAKE_CONFIG1':
+      case '/some/fake/directory/FAKE_CONFIG1':x
         return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
       case '/some/fake/directory/FAKE_CONFIG2':
         return Promise.resolve(JSON.stringify(FAKE_CONFIG2));
@@ -92,31 +92,6 @@ test('should follow dependency chain caused by extends files', async t => {
   t.deepEqual(contents, combinedConfig);
 });
 
-
-test('should throw an error if it finds a circular reference', async t => {
-  const FAKE_DIRECTORY = '/some/fake/directory';
-  const FAKE_CONFIG1 = {files: ['b'], extends: 'FAKE_CONFIG2'};
-  const FAKE_CONFIG2 = {extends: 'FAKE_CONFIG3'};
-  const FAKE_CONFIG3 = {extends: 'FAKE_CONFIG1'};
-  function fakeReadFilep(
-      configPath: string, encoding: string): Promise<string> {
-    switch (configPath) {
-      case '/some/fake/directory/FAKE_CONFIG1':
-
-      case '/some/fake/directory/FAKE_CONFIG2':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG2));
-      case '/some/fake/directory/FAKE_CONFIG3':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG3));
-      case '/some/fake/directory/tsconfig.json':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
-      default:
-        return Promise.reject('File Not Found');
-    }
-  }
-  await t.throws(
-      getTSConfig(FAKE_DIRECTORY, fakeReadFilep), Error,
-      'Circular Reference Detected');
-});
 
 test(
     'when a file contains an extends field, the base file is loaded first then overridden by the inherited files',

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -150,11 +150,11 @@ test(
     });
 
 test(
-    'when a file contains an extends field, the base file is loaded first then overridden by the inherited files',
+    'When a file, all filepaths should be relative to the config file currently being read',
     async t => {
       const FAKE_DIRECTORY = '/some/fake/directory';
-      const FAKE_CONFIG1 = {files: ['b'], extends: 'FAKE_CONFIG2'};
-      const FAKE_CONFIG2 = {include: ['c'], extends: 'FAKE_CONFIG3'};
+      const FAKE_CONFIG1 = {files: ['b'], extends: './foo/FAKE_CONFIG2'};
+      const FAKE_CONFIG2 = {include: ['c'], extends: './bar/FAKE_CONFIG3'};
       const FAKE_CONFIG3 = {exclude: ['d']};
       const combinedConfig =
           {compilerOptions: {}, exclude: ['d'], files: ['b'], include: ['c']};
@@ -163,9 +163,9 @@ test(
         switch (configPath) {
           case '/some/fake/directory/FAKE_CONFIG1':
 
-          case '/some/fake/directory/FAKE_CONFIG2':
+          case '/some/fake/directory/foo/FAKE_CONFIG2':
             return Promise.resolve(JSON.stringify(FAKE_CONFIG2));
-          case '/some/fake/directory/FAKE_CONFIG3':
+          case '/some/fake/directory/foo/bar/FAKE_CONFIG3':
             return Promise.resolve(JSON.stringify(FAKE_CONFIG3));
           case '/some/fake/directory/tsconfig.json':
             return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
@@ -176,5 +176,7 @@ test(
       const contents = await getTSConfig(FAKE_DIRECTORY, fakeReadFilep);
       t.deepEqual(contents, combinedConfig);
     });
+
+    
 
 // TODO: test errors in readFile, JSON.parse.

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -22,7 +22,7 @@ import {ConfigFile, getTSConfig} from '../src/util';
  * Creates a fake promisified readFile function from a map
  * @param myMap contains a filepath as the key and a ConfigFile object as the
  * value.
- * The returned funciton has the same interface as fs.readFile
+ * The returned function has the same interface as fs.readFile
  */
 function createFakeReadFilep(myMap: Map<string, ConfigFile>) {
   return (configPath: string) => {

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -150,7 +150,7 @@ test(
     });
 
 test(
-    'When a file, all filepaths should be relative to the config file currently being read',
+    'When reading a file, all filepaths should be relative to the config file currently being read',
     async t => {
       const FAKE_DIRECTORY = '/some/fake/directory';
       const FAKE_CONFIG1 = {files: ['b'], extends: './foo/FAKE_CONFIG2'};

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -39,7 +39,7 @@ test('should throw an error if it finds a circular reference', async t => {
   function fakeReadFilep(
       configPath: string, encoding: string): Promise<string> {
     switch (configPath) {
-      case '/some/fake/directory/FAKE_CONFIG1':x
+      case '/some/fake/directory/FAKE_CONFIG1':
         return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
       case '/some/fake/directory/FAKE_CONFIG2':
         return Promise.resolve(JSON.stringify(FAKE_CONFIG2));

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -35,20 +35,19 @@ test('should throw an error if it finds a circular reference', async t => {
   const FAKE_DIRECTORY = '/some/fake/directory';
   const FAKE_CONFIG1 = {files: ['b'], extends: 'FAKE_CONFIG2'};
   const FAKE_CONFIG2 = {extends: 'FAKE_CONFIG3'};
-  const FAKE_CONFIG3 = {extends: 'FAKE_CONFIG1'};
+  const FAKE_CONFIG3 = {extends: 'tsconfig.json'};
+  const myMap = new Map();
+  myMap.set('/some/fake/directory/tsconfig.json', FAKE_CONFIG1);
+  myMap.set('/some/fake/directory/FAKE_CONFIG2', FAKE_CONFIG2);
+  myMap.set('/some/fake/directory/FAKE_CONFIG3', FAKE_CONFIG3);
+
   function fakeReadFilep(
       configPath: string, encoding: string): Promise<string> {
-    switch (configPath) {
-      case '/some/fake/directory/FAKE_CONFIG1':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
-      case '/some/fake/directory/FAKE_CONFIG2':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG2));
-      case '/some/fake/directory/FAKE_CONFIG3':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG3));
-      case '/some/fake/directory/tsconfig.json':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
-      default:
-        return Promise.reject('File Not Found');
+    let configFile = myMap.get(configPath);
+    if (configFile) {
+      return Promise.resolve(JSON.stringify(configFile));
+    } else {
+      return Promise.reject('File Not Found');
     }
   }
   await t.throws(
@@ -73,19 +72,18 @@ test('should follow dependency chain caused by extends files', async t => {
   };
 
 
+  const myMap = new Map();
+  myMap.set('/some/fake/directory/tsconfig.json', FAKE_CONFIG1);
+  myMap.set('/some/fake/directory/FAKE_CONFIG2', FAKE_CONFIG2);
+  myMap.set('/some/fake/directory/FAKE_CONFIG3', FAKE_CONFIG3);
+
   function fakeReadFilep(
       configPath: string, encoding: string): Promise<string> {
-    switch (configPath) {
-      case '/some/fake/directory/FAKE_CONFIG1':
-
-      case '/some/fake/directory/FAKE_CONFIG2':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG2));
-      case '/some/fake/directory/FAKE_CONFIG3':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG3));
-      case '/some/fake/directory/tsconfig.json':
-        return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
-      default:
-        return Promise.reject('File Not Found');
+    let configFile = myMap.get(configPath);
+    if (configFile) {
+      return Promise.resolve(JSON.stringify(configFile));
+    } else {
+      return Promise.reject('File Not Found');
     }
   }
   const contents = await getTSConfig(FAKE_DIRECTORY, fakeReadFilep);
@@ -101,19 +99,18 @@ test(
       const FAKE_CONFIG2 = {files: ['c'], extends: 'FAKE_CONFIG3'};
       const FAKE_CONFIG3 = {files: ['d']};
       const combinedConfig = {compilerOptions: {}, files: ['b']};
+      const myMap = new Map();
+      myMap.set('/some/fake/directory/tsconfig.json', FAKE_CONFIG1);
+      myMap.set('/some/fake/directory/FAKE_CONFIG2', FAKE_CONFIG2);
+      myMap.set('/some/fake/directory/FAKE_CONFIG3', FAKE_CONFIG3);
+
       function fakeReadFilep(
           configPath: string, encoding: string): Promise<string> {
-        switch (configPath) {
-          case '/some/fake/directory/FAKE_CONFIG1':
-
-          case '/some/fake/directory/FAKE_CONFIG2':
-            return Promise.resolve(JSON.stringify(FAKE_CONFIG2));
-          case '/some/fake/directory/FAKE_CONFIG3':
-            return Promise.resolve(JSON.stringify(FAKE_CONFIG3));
-          case '/some/fake/directory/tsconfig.json':
-            return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
-          default:
-            return Promise.reject('File Not Found');
+        let configFile = myMap.get(configPath);
+        if (configFile) {
+          return Promise.resolve(JSON.stringify(configFile));
+        } else {
+          return Promise.reject('File Not Found');
         }
       }
       const contents = await getTSConfig(FAKE_DIRECTORY, fakeReadFilep);
@@ -129,19 +126,18 @@ test(
       const FAKE_CONFIG3 = {exclude: ['d']};
       const combinedConfig =
           {compilerOptions: {}, exclude: ['d'], files: ['b'], include: ['c']};
+      const myMap = new Map();
+      myMap.set('/some/fake/directory/tsconfig.json', FAKE_CONFIG1);
+      myMap.set('/some/fake/directory/foo/FAKE_CONFIG2', FAKE_CONFIG2);
+      myMap.set('/some/fake/directory/foo/bar/FAKE_CONFIG3', FAKE_CONFIG3);
+
       function fakeReadFilep(
           configPath: string, encoding: string): Promise<string> {
-        switch (configPath) {
-          case '/some/fake/directory/FAKE_CONFIG1':
-
-          case '/some/fake/directory/foo/FAKE_CONFIG2':
-            return Promise.resolve(JSON.stringify(FAKE_CONFIG2));
-          case '/some/fake/directory/foo/bar/FAKE_CONFIG3':
-            return Promise.resolve(JSON.stringify(FAKE_CONFIG3));
-          case '/some/fake/directory/tsconfig.json':
-            return Promise.resolve(JSON.stringify(FAKE_CONFIG1));
-          default:
-            return Promise.reject('File Not Found');
+        let configFile = myMap.get(configPath);
+        if (configFile) {
+          return Promise.resolve(JSON.stringify(configFile));
+        } else {
+          return Promise.reject(`${configPath} Not Found`);
         }
       }
       const contents = await getTSConfig(FAKE_DIRECTORY, fakeReadFilep);

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -21,7 +21,7 @@ import {ConfigFile, getTSConfig} from '../src/util';
 /**
  * Creates a fake promisified readFile function from a map
  * @param myMap contains a filepath as the key and a ConfigFile object as the
- * value. 
+ * value.
  * The returned funciton has the same interface as fs.readFile
  */
 function createFakeReadFilep(myMap: Map<string, ConfigFile>) {
@@ -126,6 +126,17 @@ test(
       const contents =
           await getTSConfig(FAKE_DIRECTORY, createFakeReadFilep(myMap));
       t.deepEqual(contents, combinedConfig);
+    });
+
+test(
+    'function throws an error when reading a file that does not exist',
+    async t => {
+      const FAKE_DIRECTORY = '/some/fake/directory';
+      const myMap = new Map();
+
+      await t.throws(
+          getTSConfig(FAKE_DIRECTORY, createFakeReadFilep(myMap)), Error,
+          `${FAKE_DIRECTORY}/tsconfig.json Not Found`);
     });
 
 

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -71,7 +71,6 @@ test('should follow dependency chain caused by extends files', async t => {
     exclude: ['doesnt/look/like/anything/to/me']
   };
 
-
   const myMap = new Map();
   myMap.set('/some/fake/directory/tsconfig.json', FAKE_CONFIG1);
   myMap.set('/some/fake/directory/FAKE_CONFIG2', FAKE_CONFIG2);
@@ -89,7 +88,6 @@ test('should follow dependency chain caused by extends files', async t => {
   const contents = await getTSConfig(FAKE_DIRECTORY, fakeReadFilep);
   t.deepEqual(contents, combinedConfig);
 });
-
 
 test(
     'when a file contains an extends field, the base file is loaded first then overridden by the inherited files',

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -33,7 +33,6 @@ test('get should parse the correct tsconfig file', async t => {
 
 
 
-// TODO: test for error due to circular reference
 test('should throw an error if it finds a circular reference', async t => {
   const FAKE_DIRECTORY = '/some/fake/directory';
   const FAKE_CONFIG1 = {files: ['b'], extends: 'FAKE_CONFIG2'};

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -174,4 +174,3 @@ test(
     });
 
 // TODO: test errors in readFile, JSON.parse.
- 

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -63,14 +63,14 @@ test('should throw an error if it finds a circular reference', async t => {
 test('should follow dependency chain caused by extends files', async t => {
   const FAKE_DIRECTORY = '/some/fake/directory';
   const FAKE_CONFIG1 = {
-    compilerOptions: {compileExtraFastPleas: 'SuperSpeed'},
+    compilerOptions: {a: 'n'},
     files: ['b'],
     extends: 'FAKE_CONFIG2'
   };
   const FAKE_CONFIG2 = {include: ['/stuff/*'], extends: 'FAKE_CONFIG3'};
   const FAKE_CONFIG3 = {exclude: ['doesnt/look/like/anything/to/me']};
   const combinedConfig = {
-    compilerOptions: {compileExtraFastPleas: 'SuperSpeed'},
+    compilerOptions: {a: 'n'},
     files: ['b'],
     include: ['/stuff/*'],
     exclude: ['doesnt/look/like/anything/to/me']
@@ -177,6 +177,6 @@ test(
       t.deepEqual(contents, combinedConfig);
     });
 
-    
+
 
 // TODO: test errors in readFile, JSON.parse.

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -20,7 +20,7 @@ import {getTSConfig} from '../src/util';
 
 test('get should parse the correct tsconfig file', async t => {
   const FAKE_DIRECTORY = '/some/fake/directory';
-  const FAKE_CONFIG = {a: 'b'};
+  const FAKE_CONFIG = {files: ['b']};
   function fakeReadFilep(
       configPath: string, encoding: string): Promise<string> {
     t.is(configPath, path.join(FAKE_DIRECTORY, 'tsconfig.json'));
@@ -30,5 +30,75 @@ test('get should parse the correct tsconfig file', async t => {
   const contents = await getTSConfig(FAKE_DIRECTORY, fakeReadFilep);
   t.deepEqual(contents, FAKE_CONFIG);
 });
+
+
+
+// TODO: test for error due to circular reference
+test('should throw an error if it finds a circular reference', async t => {
+  const FAKE_DIRECTORY = '/some/fake/directory';
+  const FAKE_CONFIG = {files: ['b'], extends: 'CONFIG1'};
+  const CONFIG1 = {extends: 'CONFIG2'};
+  const CONFIG2 = {extends: 'FAKE_CONFIG'};
+  function fakeReadFilep(
+      configPath: string, encoding: string): Promise<string> {
+    switch (configPath) {
+      case 'FAKE_CONFIG':
+
+      case 'CONFIG1':
+        return Promise.resolve(JSON.stringify(CONFIG1));
+      case 'CONFIG2':
+        return Promise.resolve(JSON.stringify(CONFIG2));
+      case '/some/fake/directory/tsconfig.json':
+        return Promise.resolve(JSON.stringify(FAKE_CONFIG));
+      default:
+        return Promise.reject('File Not Found');
+    }
+  }
+  await t.throws(
+      getTSConfig(FAKE_DIRECTORY, fakeReadFilep), Error,
+      'Circular Reference Detected');
+});
+
+
+test('should follow dependency chain caused by extends files', async t => {
+  const FAKE_DIRECTORY = '/some/fake/directory';
+  const FAKE_CONFIG = {
+    compilerOptions: {compileExtraFastPleas: 'SuperSpeed'},
+    files: ['b'],
+    extends: 'CONFIG1'
+  };
+  const CONFIG1 = {include: ['/stuff/*'], extends: 'CONFIG2'};
+  const CONFIG2 = {exclude: ['doesnt/look/like/anything/to/me']};
+  const combinedConfig = {
+    compilerOptions: {compileExtraFastPleas: 'SuperSpeed'},
+    files: ['b'],
+    include: ['/stuff/*'],
+    exclude: ['doesnt/look/like/anything/to/me']
+  };
+
+
+  function fakeReadFilep(
+      configPath: string, encoding: string): Promise<string> {
+    switch (configPath) {
+      case 'FAKE_CONFIG':
+
+      case 'CONFIG1':
+        return Promise.resolve(JSON.stringify(CONFIG1));
+      case 'CONFIG2':
+        return Promise.resolve(JSON.stringify(CONFIG2));
+      case '/some/fake/directory/tsconfig.json':
+        return Promise.resolve(JSON.stringify(FAKE_CONFIG));
+      default:
+        return Promise.reject('File Not Found');
+    }
+  }
+  const contents = await getTSConfig(FAKE_DIRECTORY, fakeReadFilep);
+  t.deepEqual(contents, combinedConfig);
+});
+
+
+
+// TODO: test for circular reference error with symlinks
+
 
 // TODO: test errors in readFile, JSON.parse.

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -31,8 +31,6 @@ test('get should parse the correct tsconfig file', async t => {
   t.deepEqual(contents, FAKE_CONFIG1);
 });
 
-
-
 test('should throw an error if it finds a circular reference', async t => {
   const FAKE_DIRECTORY = '/some/fake/directory';
   const FAKE_CONFIG1 = {files: ['b'], extends: 'FAKE_CONFIG2'};
@@ -57,7 +55,6 @@ test('should throw an error if it finds a circular reference', async t => {
       getTSConfig(FAKE_DIRECTORY, fakeReadFilep), Error,
       'Circular Reference Detected');
 });
-
 
 test('should follow dependency chain caused by extends files', async t => {
   const FAKE_DIRECTORY = '/some/fake/directory';


### PR DESCRIPTION
 I wrote and edited the tests to show the new functionality and to catch circular references. This still should be abstracted to effect all commands that look at the contents of tsconfig.json. Also there is no support for compileOnSave yet. fix: #64 