### PR TITLE
chore(release): bump version for 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gts",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gts",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Google TypeScript Style",
   "repository": "google/ts-style",
   "main": "build/src/index.js",


### PR DESCRIPTION
[release notes](https://github.com/google/ts-style/releases/edit/untagged-8135d45fa5980f0bd20b)

---
This is a release with breaking changes. We no longer set the `esModuleInterop` and `allowSyntheticDefaultImports` in the default TypeScript config. These might be reasonable configurations for end-user application code, but for libraries these can be problematic. TypeScript users of such libraries must have these flags set as well for compilation to succeed. For example: https://github.com/google/google-auth-library-nodejs/issues/381.

There are two ways to deal with this breaking change:
* (recommended) change code using synthetic imports (`import fs from 'fs'`) back to using old style imports (`import * as fs from 'fs'`).
* Add `"esModuleInterop": true` to your local `tsconfig.json`.

Sorry for the churn.

### Commits
* d92f876 fix: also disable allowSyntheticDefaultImports (#184)
* 94360af fix: disable esModuleInterop (#183)
* b2b5bbd test: add more tests (#182)
* 122fe81 fix(init): init package with better main, types (#179)