### PR TITLE
fix: Upgrade init'ed and allowed versions of TypeScript (closes #203)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "~3.0.0"
   },
   "peerDependencies": {
-    "typescript": "^2.7.1"
+    "typescript": "^2.7.1 || ^3.0.0"
   },
   "ava": {
     "require": [

--- a/src/init.ts
+++ b/src/init.ts
@@ -114,7 +114,10 @@ export async function addScripts(
 export async function addDependencies(
     packageJson: PackageJson, options: Options): Promise<boolean> {
   let edits = false;
-  const deps: Bag<string> = {'gts': `^${pkg.version}`, 'typescript': '~2.8.0'};
+  const deps: Bag<string> = {
+    gts: `^${pkg.version}`,
+    typescript: pkg.devDependencies.typescript
+  };
 
   if (!packageJson.devDependencies) {
     packageJson.devDependencies = {};


### PR DESCRIPTION
When this PR is merged
- Package `gts` will allow TypeScript 3.x as a peer dependency
- Command `gts init` will install `typescript@~3.0.0`
- (Implementation detail): The `gts init`-installed version of typescript will be derived from this package's devDependencies.