### PR TITLE
README.md invisible fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ When you run the `npx gts init` command, it's going to do a few things for you:
 ## Individual files
 The commands above will all run in the scope of the current folder.  Some commands can be run on individual files:
 
-```js
-$ gts check index.ts
-$ gts check one.ts two.ts three.ts
-$ gts check *.ts
+```sh
+gts check index.ts
+gts check one.ts two.ts three.ts
+gts check *.ts
 ```
 
 # License
@@ -72,4 +72,3 @@ See [LICENSE](LICENSE)
 [snyk-url]: https://snyk.io/test/github/google/ts-style
 [standardjs-url]: https://www.npmjs.com/package/standard
 [tslint-url]: https://palantir.github.io/tslint/
-


### PR DESCRIPTION
- Changed code block language from `js` to `sh`, since it's more appropriate for that code block. `sh` alias for Shell was picked for consistency with other code blocks (also `sh`) and because it's valid [supported by linguist](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L4459) (which is used by GitHub) alias for Shell. This code block was added by 11bf7ded1c2a4da6e76b857dca94e2c4befa3850 commit.
- Removed unnecessary *second* empty line from the end of the file. One empty line should be enough. Extra empty line was added by d4f6aaaed21a98c773bf6ca2c335f719cd39f70b commit.