### PR TITLE
Removed gitAuthor from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,5 @@
   "lockFileMaintenance": {
     "enabled": true,
     "recreateClosed": true
-  },
-  "gitAuthor": null
+  }
 }


### PR DESCRIPTION
Removed `"gitAuthor": null` from `renovate.json` file, because renovate requires [RFC5322-compliant string](https://github.com/renovatebot/renovate/blob/master/website/docs/self-hosted-configuration.md#gitauthor) and `null` is not a string. Furthermore, the default value for `gitAuthor` is `null` according to [docs](https://renovatebot.com/docs/self-hosted-configuration/#gitauthor).

This file was added in e107ab3e9180a69c74aafe7eb683a0f6d70bd7dc commit and was never changed after that.