### PR TITLE
Removed redundant escape characters from RegExps

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -162,10 +162,10 @@ export function getReplacements(fileXML: string): Replacement[] {
     // Uses regex to capture the xml attributes and element
     // XML format:
     // <replacement offset='OFFSET' length='LENGTH'>FIX</replacement>
-    const offset: string[]|null = (/offset=\'(\d+)\'/g).exec(xmlLines[i]);
-    const length: string[]|null = (/length=\'(\d+)\'/g).exec(xmlLines[i]);
+    const offset: string[]|null = (/offset='(\d+)'/g).exec(xmlLines[i]);
+    const length: string[]|null = (/length='(\d+)'/g).exec(xmlLines[i]);
     const fix: string[]|null =
-        (/length=\'\d+\'>(.*)<\/replacement>/g).exec(xmlLines[i]);
+        (/length='\d+'>(.*)<\/replacement>/g).exec(xmlLines[i]);
 
     if (length === null || offset === null || fix === null) {
       throw new Error('Unable to get replacement');


### PR DESCRIPTION
There is no need for escape escaping `'` (single quotes) in those regular expressions, since we're not wrapping whole regular expression in single quotes. It means that we're safe here even without escape characters.
Those regular expressions first appeared in f7c75ee67c534a2f980922d93463ca637546c0ad commit and were never changed.