### PR TITLE
fix: do not allow deprecated methods

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,7 @@
     ],
     "class-name": true,
     "curly": [true, "ignore-same-line"],
+    "deprecation": true,
     "forin": true,
     "interface-name": [true, "never-prefix"],
     "jsdoc-format": true,


### PR DESCRIPTION
Our eslint config checks to make sure we don't use deprecated APIs, and throws in that case.  Our tslint config does not.  This bit us in real life, where an `assert.equal` was allowed to get checked in, and it didn't properly check strictness.